### PR TITLE
Add Jupyter live kernel skill and demo assets

### DIFF
--- a/.claude/skills/jupyter-live-kernel/SKILL.md
+++ b/.claude/skills/jupyter-live-kernel/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: jupyter-live-kernel
+description: Work against a live local Jupyter notebook kernel. Use this when an agent needs a Jupyter-like in-memory REPL, wants to inspect or edit a notebook while keeping the kernel alive, or needs an explicit verification pass at the end.
+---
+
+# Jupyter Live Kernel
+
+This is the Claude Code entrypoint for the shared skill in this repo.
+
+Use the shared skill files as the source of truth:
+- `../../../skills/jupyter-live-kernel/SKILL.md`
+- `../../../skills/jupyter-live-kernel/scripts/jupyter_live_kernel.py`
+- `../../../skills/jupyter-live-kernel/references/jupyter-hooks.md`
+
+Follow the shared `SKILL.md` for behavior, command order, limits, and examples.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+__pycache__/
+*.py[cod]
+video/node_modules/
+video/out/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# AGENTS.md
+
+This repo contains a Codex skill for working against a live local Jupyter notebook kernel without rerunning whole scripts.
+
+Canonical doc:
+- [SKILL.md](/Users/hamel/git/hamelnb/skills/jupyter-live-kernel/SKILL.md) is the source of truth for command semantics and limits.
+
+Primary files:
+- [SKILL.md](/Users/hamel/git/hamelnb/skills/jupyter-live-kernel/SKILL.md)
+- [jupyter_live_kernel.py](/Users/hamel/git/hamelnb/skills/jupyter-live-kernel/scripts/jupyter_live_kernel.py)
+- [test_jupyter_live_kernel.py](/Users/hamel/git/hamelnb/tests/test_jupyter_live_kernel.py)
+
+## Fastest Test Path
+
+```bash
+python3 -m unittest -v tests/test_jupyter_live_kernel.py
+```
+
+This covers:
+- server discovery
+- notebook/session listing
+- contents fetch
+- cell edits and output clearing
+- execute over `websocket` and `zmq`
+- `restart`, `run-all`, and `restart-run-all`
+- variable listing and preview
+- target validation, auth handling, stale-write protection, and transport safety guards
+
+## Manual Smoke Test
+
+Start a disposable JupyterLab:
+
+```bash
+mkdir -p /tmp/jupyter-live-kernel-demo
+jupyter lab \
+  --no-browser \
+  --IdentityProvider.token=testtoken \
+  --ServerApp.password= \
+  --ServerApp.port=8899 \
+  --ServerApp.port_retries=0 \
+  --ServerApp.root_dir=/tmp/jupyter-live-kernel-demo
+```
+
+Then run:
+
+```bash
+SCRIPT=skills/jupyter-live-kernel/scripts/jupyter_live_kernel.py
+python3 "$SCRIPT" servers --compact
+python3 "$SCRIPT" notebooks --port 8899 --compact
+python3 "$SCRIPT" contents --port 8899 --path demo.ipynb --compact
+python3 "$SCRIPT" execute --port 8899 --path demo.ipynb --code $'x = 41\nx + 1' --compact
+python3 "$SCRIPT" variables --port 8899 --path demo.ipynb list --compact
+python3 "$SCRIPT" run-all --port 8899 --path demo.ipynb --compact
+```
+
+## Operating Order
+
+Use this order unless you have a reason not to:
+1. `servers`
+2. `notebooks`
+3. `contents`
+4. `edit` and `execute`
+5. `variables` when you need live kernel state
+6. `restart`, `run-all`, or `restart-run-all` only when the user explicitly wants a fresh run or verification pass
+
+## Important Limits
+
+- `contents` shows the saved notebook, not unsaved browser edits.
+- workspace-derived notebook tabs are a persisted JupyterLab snapshot and can include historical workspaces for the same relative path.
+- `edit` changes the saved notebook on disk.
+- `edit clear-outputs` clears saved outputs on disk only.
+- `execute`, `restart`, `variables`, `run-all`, and `restart-run-all` target live notebook sessions.
+- `run-all` and `restart-run-all` exit non-zero when a cell fails.
+- `run-all` and `restart-run-all` do not persist outputs into the notebook.
+- variable preview is bounded and avoids arbitrary `repr(...)` calls for non-scalar objects.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-This repo contains a Codex skill for working against a live local Jupyter notebook kernel without rerunning whole scripts.
+This repo contains a shared skill for working against a live local Jupyter notebook kernel without rerunning whole scripts.
 
 Canonical doc:
 - [SKILL.md](/Users/hamel/git/hamelnb/skills/jupyter-live-kernel/SKILL.md) is the source of truth for command semantics and limits.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,37 @@
 # hamelnb
 
-`hamelnb` gives Codex a practical live Jupyter notebook workflow against a running local kernel.
+`hamelnb` lets a coding agent work with a live local notebook.
 
-It is worth trying if you debug or iterate in stateful notebooks and do not want every small fix to trigger a full rerun.
+It helps when part of your workflow takes a long time to run and you do not want every small fix to start over.
+
+Notebooks are useful for data analysis, debugging, and exploratory work. This skill brings that workflow into a coding agent without asking you to leave the tools you already use.
 
 Use it when:
-- a notebook already holds expensive in-memory state and you do not want to rerun setup cells
-- you need to inspect or edit a notebook while keeping the kernel alive
-- you want an explicit end-of-task verification pass with `run-all` or `restart-run-all`
+- some notebook steps are slow and you want to keep that work alive
+- you want your coding agent to inspect or edit notebook cells
+- you want to test a change against the live notebook state instead of rerunning everything
+- you want an explicit reset or verification pass at the end
 
-It provides:
-- local Jupyter server and notebook-session discovery
-- saved notebook inspection
-- notebook cell edits through the Contents API
-- incremental kernel execution
-- saved-output clearing
-- kernel restart
-- notebook-wide verification without saving outputs back into the notebook
-- bounded live variable inspection for Python kernels
+What it does:
+- finds local notebook sessions
+- reads saved notebook contents
+- edits notebook cells
+- runs code in the live notebook kernel
+- inspects live Python variables
+- clears saved outputs
+- restarts and verifies notebooks when you ask for it
+
+Start here:
+- [AGENTS.md](/Users/hamel/git/hamelnb/AGENTS.md) for the shortest operator path
+- [SKILL.md](/Users/hamel/git/hamelnb/skills/jupyter-live-kernel/SKILL.md) for command behavior and limits
+
+## How It Works
+
+The skill connects to a local Jupyter server, finds live notebook sessions, reads the saved notebook file, and sends code to the running kernel.
+
+That gives an agent two useful modes:
+- the normal loop: inspect, edit, run a small change, inspect variables, repeat
+- the verification loop: restart and run the notebook from the top when you explicitly want a fresh check
 
 Key limits:
 - notebook reads come from the saved `.ipynb`, not unsaved browser edits in JupyterLab
@@ -26,42 +40,38 @@ Key limits:
 - variable inspection is Python-only and preview is intentionally bounded
 - this project targets local Jupyter servers
 
-Start here:
-- [AGENTS.md](/Users/hamel/git/hamelnb/AGENTS.md) for the shortest operator path
-- [SKILL.md](/Users/hamel/git/hamelnb/skills/jupyter-live-kernel/SKILL.md) for canonical command behavior and limits
+## Install the Skill
 
-## Claude Code
+### Codex
 
-If you want to use this repo from Claude Code, install Claude Code first and then run the helper script from this repo directly.
-
-Recommended install:
+Install it into your Codex skills directory:
 
 ```bash
-curl -fsSL https://claude.ai/install.sh | bash
+DEST="${CODEX_HOME:-$HOME/.codex}/skills/jupyter-live-kernel"
+rm -rf "$DEST"
+mkdir -p "$(dirname "$DEST")"
+cp -R skills/jupyter-live-kernel "$DEST"
 ```
 
-Other official install options:
-- Windows PowerShell: `irm https://claude.ai/install.ps1 | iex`
-- Windows CMD: `curl -fsSL https://claude.ai/install.cmd -o install.cmd && install.cmd && del install.cmd`
-- Homebrew: `brew install --cask claude-code`
-- WinGet: `winget install Anthropic.ClaudeCode`
+Then restart Codex.
 
-Then start Claude Code and log in:
+### Claude Code
+
+Claude Code reads skills from `.claude/skills/` in the current project or `~/.claude/skills/` for all projects.
+
+Install it for this project:
 
 ```bash
-claude
+DEST=".claude/skills/jupyter-live-kernel"
+rm -rf "$DEST"
+mkdir -p "$(dirname "$DEST")"
+cp -R skills/jupyter-live-kernel "$DEST"
 ```
 
-Verify the install:
+If you want it in every project, replace `.claude` with `~/.claude`.
 
-```bash
-claude --version
-```
-
-Notes:
-- Anthropic recommends the native installer. The npm install path is deprecated.
-- Windows requires Git for Windows.
-- Official docs: [Claude Code setup](https://code.claude.com/docs/en/setup) and [quickstart](https://code.claude.com/docs/en/quickstart)
+Reference:
+- [Claude Code skills docs](https://code.claude.com/docs/en/slash-commands)
 
 ## Project Layout
 

--- a/README.md
+++ b/README.md
@@ -46,37 +46,43 @@ This skill works with both Codex and Claude Code. The install steps differ only 
 
 ### Codex
 
-Install it into your Codex skills directory:
+Codex has a built-in GitHub skill installer. Install the skill directly from this repo:
 
 ```bash
-DEST="${CODEX_HOME:-$HOME/.codex}/skills/jupyter-live-kernel"
-rm -rf "$DEST"
-mkdir -p "$(dirname "$DEST")"
-cp -R skills/jupyter-live-kernel "$DEST"
+python3 "${CODEX_HOME:-$HOME/.codex}/skills/.system/skill-installer/scripts/install-skill-from-github.py" \
+  --repo hamelsmu/hamelnb \
+  --path skills/jupyter-live-kernel
 ```
 
 Then restart Codex.
 
 ### Claude Code
 
-Claude Code reads skills from `.claude/skills/` in the current project or `~/.claude/skills/` for all projects.
+Claude Code loads skills from `.claude/skills/`, including repos you add with `--add-dir`.
 
-Install it for this project:
+Clone this repo somewhere stable, then add it when you start Claude Code:
 
 ```bash
-DEST=".claude/skills/jupyter-live-kernel"
-rm -rf "$DEST"
-mkdir -p "$(dirname "$DEST")"
-cp -R skills/jupyter-live-kernel "$DEST"
+git clone https://github.com/hamelsmu/hamelnb.git ~/.agent-skills/hamelnb
+claude --add-dir ~/.agent-skills/hamelnb
 ```
 
-If you want it in every project, replace `.claude` with `~/.claude`.
+If you are already in a Claude Code session, run `/add-dir ~/.agent-skills/hamelnb`.
+
+If you want the skill available in every project without `--add-dir`, symlink it into `~/.claude/skills/`:
+
+```bash
+git clone https://github.com/hamelsmu/hamelnb.git ~/.agent-skills/hamelnb
+mkdir -p ~/.claude/skills
+ln -s ~/.agent-skills/hamelnb/.claude/skills/jupyter-live-kernel ~/.claude/skills/jupyter-live-kernel
+```
 
 Reference:
 - [Claude Code skills docs](https://code.claude.com/docs/en/slash-commands)
 
 ## Project Layout
 
+- `.claude/skills/jupyter-live-kernel/`: Claude Code entrypoint for the shared skill
 - `skills/jupyter-live-kernel/`: the shared skill files
 - `skills/jupyter-live-kernel/scripts/jupyter_live_kernel.py`: discovery, edit, execution, verification, and variable commands
 - `skills/jupyter-live-kernel/references/jupyter-hooks.md`: Jupyter API and extension notes

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Key limits:
 - variable inspection is Python-only and preview is intentionally bounded
 - this project targets local Jupyter servers
 
+This skill works with both Codex and Claude Code. The install steps differ only because each tool uses a different skills directory.
+
 ## Install the Skill
 
 ### Codex
@@ -75,7 +77,7 @@ Reference:
 
 ## Project Layout
 
-- `skills/jupyter-live-kernel/`: the Codex skill
+- `skills/jupyter-live-kernel/`: the shared skill files
 - `skills/jupyter-live-kernel/scripts/jupyter_live_kernel.py`: discovery, edit, execution, verification, and variable commands
 - `skills/jupyter-live-kernel/references/jupyter-hooks.md`: Jupyter API and extension notes
 - `tests/test_jupyter_live_kernel.py`: unit and end-to-end coverage

--- a/README.md
+++ b/README.md
@@ -1,0 +1,77 @@
+# hamelnb
+
+`hamelnb` gives Codex a practical live Jupyter notebook workflow against a running local kernel.
+
+It is worth trying if you debug or iterate in stateful notebooks and do not want every small fix to trigger a full rerun.
+
+Use it when:
+- a notebook already holds expensive in-memory state and you do not want to rerun setup cells
+- you need to inspect or edit a notebook while keeping the kernel alive
+- you want an explicit end-of-task verification pass with `run-all` or `restart-run-all`
+
+It provides:
+- local Jupyter server and notebook-session discovery
+- saved notebook inspection
+- notebook cell edits through the Contents API
+- incremental kernel execution
+- saved-output clearing
+- kernel restart
+- notebook-wide verification without saving outputs back into the notebook
+- bounded live variable inspection for Python kernels
+
+Key limits:
+- notebook reads come from the saved `.ipynb`, not unsaved browser edits in JupyterLab
+- workspace-derived notebook tabs are a persisted JupyterLab snapshot and may include historical workspaces for the same relative path
+- `run-all` and `restart-run-all` verify a saved snapshot loaded at the start and do not persist outputs
+- variable inspection is Python-only and preview is intentionally bounded
+- this project targets local Jupyter servers
+
+Start here:
+- [AGENTS.md](/Users/hamel/git/hamelnb/AGENTS.md) for the shortest operator path
+- [SKILL.md](/Users/hamel/git/hamelnb/skills/jupyter-live-kernel/SKILL.md) for canonical command behavior and limits
+
+## Claude Code
+
+If you want to use this repo from Claude Code, install Claude Code first and then run the helper script from this repo directly.
+
+Recommended install:
+
+```bash
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+Other official install options:
+- Windows PowerShell: `irm https://claude.ai/install.ps1 | iex`
+- Windows CMD: `curl -fsSL https://claude.ai/install.cmd -o install.cmd && install.cmd && del install.cmd`
+- Homebrew: `brew install --cask claude-code`
+- WinGet: `winget install Anthropic.ClaudeCode`
+
+Then start Claude Code and log in:
+
+```bash
+claude
+```
+
+Verify the install:
+
+```bash
+claude --version
+```
+
+Notes:
+- Anthropic recommends the native installer. The npm install path is deprecated.
+- Windows requires Git for Windows.
+- Official docs: [Claude Code setup](https://code.claude.com/docs/en/setup) and [quickstart](https://code.claude.com/docs/en/quickstart)
+
+## Project Layout
+
+- `skills/jupyter-live-kernel/`: the Codex skill
+- `skills/jupyter-live-kernel/scripts/jupyter_live_kernel.py`: discovery, edit, execution, verification, and variable commands
+- `skills/jupyter-live-kernel/references/jupyter-hooks.md`: Jupyter API and extension notes
+- `tests/test_jupyter_live_kernel.py`: unit and end-to-end coverage
+
+## Running Tests
+
+```bash
+python3 -m unittest -v tests/test_jupyter_live_kernel.py
+```

--- a/skills/jupyter-live-kernel/SKILL.md
+++ b/skills/jupyter-live-kernel/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: jupyter-live-kernel
+description: Work against a live local Jupyter notebook kernel. Use this when Codex needs a Jupyter-like in-memory REPL, wants to inspect or edit a notebook while keeping the kernel alive, or needs an explicit verification pass at the end.
+---
+
+# Jupyter Live Kernel
+
+Use this skill when a local notebook kernel already holds useful state and you do not want to rerun expensive setup.
+
+## Core Loop
+
+Run from the repo root.
+
+```bash
+SCRIPT=skills/jupyter-live-kernel/scripts/jupyter_live_kernel.py
+```
+
+1. Discover reachable servers.
+```bash
+python3 "$SCRIPT" servers --compact
+```
+
+2. Find live notebooks.
+```bash
+python3 "$SCRIPT" notebooks --port 8899 --compact
+```
+
+3. Inspect the saved notebook.
+```bash
+python3 "$SCRIPT" contents --port 8899 --path demo.ipynb --compact
+```
+
+4. Execute code incrementally in the live kernel.
+```bash
+python3 "$SCRIPT" execute \
+  --port 8899 \
+  --path demo.ipynb \
+  --code $'x = 41\nprint("hello")\nx + 1' \
+  --compact
+```
+
+5. Edit saved notebook cells.
+Use a real cell ID returned by `contents`.
+```bash
+python3 "$SCRIPT" edit \
+  --port 8899 \
+  --path demo.ipynb \
+  replace-source \
+  --cell-id <cell-id> \
+  --source $'x = 42\nx' \
+  --compact
+```
+
+Core guidance:
+- Prefer `--cell-id` over `--index` for existing cells.
+- Use `execute` for the normal loop.
+- Keep `restart`, `run-all`, and `restart-run-all` for explicit verification or reset requests, not routine iteration.
+
+## Advanced
+
+Inspect live Python-kernel variables:
+
+```bash
+python3 "$SCRIPT" variables --port 8899 --path demo.ipynb list --compact
+python3 "$SCRIPT" variables --port 8899 --path demo.ipynb preview --name x --compact
+```
+
+Verification commands:
+
+```bash
+python3 "$SCRIPT" restart --port 8899 --path demo.ipynb --compact
+python3 "$SCRIPT" run-all --port 8899 --path demo.ipynb --compact
+python3 "$SCRIPT" restart-run-all --port 8899 --path demo.ipynb --compact
+```
+
+Advanced guidance:
+- `variables` is Python-only.
+- `run-all` and `restart-run-all` require a notebook-backed live session.
+- `run-all` and `restart-run-all` exit non-zero when a cell fails.
+- `run-all` and `restart-run-all` verify a saved snapshot loaded at the start.
+- `run-all` and `restart-run-all` do not write outputs back into the notebook file.
+
+## Transport
+
+`execute`, `variables`, `run-all`, and `restart-run-all` default to `--transport auto`.
+
+- `websocket`: use Jupyter Server kernel channels at `/api/kernels/<kernel_id>/channels`
+- `zmq`: fall back to the local kernel connection file with `jupyter_client`
+- `auto`: try websocket first, then use local ZMQ fallback only when the websocket request did not already reach the kernel
+
+Prefer `auto` unless you are debugging transport behavior.
+
+## Limits
+
+- `contents` returns the saved notebook file, not unsaved browser edits.
+- `edit` writes through the Contents API and changes the saved notebook on disk.
+- The stale-write guard is best-effort, not atomic.
+- Concurrent notebook edits can invalidate a verification run after it starts.
+- Concurrent execution from other clients can affect kernel state during verification.
+- Variable listing is bounded to `--limit <= 100`.
+- Variable preview is bounded to `--max-chars <= 2000` and avoids arbitrary `repr(...)` calls for non-scalar objects.
+- Workspace-derived notebook tabs are a persisted JupyterLab snapshot, not guaranteed real-time UI truth.
+- Workspace-derived notebook tabs can include historical workspaces for the same relative path.
+- The skill assumes local Jupyter runtime metadata is visible to the current user.
+
+## Resources
+
+- Script: [jupyter_live_kernel.py](/Users/hamel/git/hamelnb/skills/jupyter-live-kernel/scripts/jupyter_live_kernel.py)
+- Architecture notes: [jupyter-hooks.md](/Users/hamel/git/hamelnb/skills/jupyter-live-kernel/references/jupyter-hooks.md)

--- a/skills/jupyter-live-kernel/SKILL.md
+++ b/skills/jupyter-live-kernel/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jupyter-live-kernel
-description: Work against a live local Jupyter notebook kernel. Use this when Codex needs a Jupyter-like in-memory REPL, wants to inspect or edit a notebook while keeping the kernel alive, or needs an explicit verification pass at the end.
+description: Work against a live local Jupyter notebook kernel. Use this when an agent needs a Jupyter-like in-memory REPL, wants to inspect or edit a notebook while keeping the kernel alive, or needs an explicit verification pass at the end.
 ---
 
 # Jupyter Live Kernel

--- a/skills/jupyter-live-kernel/agents/openai.yaml
+++ b/skills/jupyter-live-kernel/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Jupyter Live Kernel"
+  short_description: "Inspect live notebooks and run kernel code."
+  default_prompt: "Inspect a local JupyterLab or Jupyter Server instance, list live notebook sessions, read saved notebook contents, and execute code incrementally in an existing kernel."

--- a/skills/jupyter-live-kernel/references/jupyter-hooks.md
+++ b/skills/jupyter-live-kernel/references/jupyter-hooks.md
@@ -1,0 +1,64 @@
+# Jupyter Hooks
+
+## Core server hooks
+
+Use these server endpoints for the skill-first path:
+
+- `GET /api/sessions`: list live notebook sessions and their kernels
+- `GET /api/contents/<path>?type=notebook&content=1`: fetch saved notebook JSON
+- `PUT /api/contents/<path>`: save an updated notebook JSON model
+- `GET /lab/api/workspaces`: inspect persisted JupyterLab layout state
+- `GET /api/kernels/<kernel_id>/channels` over WebSocket: execute code incrementally against a live kernel
+
+The local helper script discovers running servers with `jupyter_server.serverapp.list_running_servers()` and then probes each server instead of trusting runtime records blindly.
+
+## JupyterLab frontend hooks
+
+If the server-side skill is not enough, the JupyterLab extension path is:
+
+- `INotebookTracker`: enumerate notebook widgets, watch `currentWidget`, `currentChanged`, and `widgetAdded`
+- `NotebookPanel.sessionContext`: access the notebook's current session and kernel connection
+- `KernelConnection.requestExecute(...)`: submit code without restarting the kernel
+- `ContentsManager.get(...)`: fetch the notebook model through the standard services client
+
+That path gives the truest UI view, including which notebook tabs are open in the active Lab frontend.
+
+## Recommended architecture
+
+Start with the skill and helper script. It already covers the useful workflow:
+
+1. discover local Jupyter servers
+2. list live notebook sessions
+3. inspect notebook contents
+4. edit saved notebook cells through whole-notebook fetch/mutate/save
+5. execute incremental snippets in an existing kernel
+
+For notebook editing, prefer stable cell IDs over positional indices. Indices remain useful for inserts and moves, but existing cells should be targeted by ID when possible.
+
+Because these edits use read-modify-write through the Contents API, add a stale-write guard. If the notebook's `last_modified` timestamp changes between load and save, abort and reload instead of silently overwriting newer content.
+
+Only add a JupyterLab plugin if you specifically need:
+
+- exact real-time browser tab state
+- unsaved notebook document content
+- a direct frontend bridge instead of polling server and workspace state
+
+## Important limitations
+
+- Workspace state is persisted UI state, not a hard guarantee of current browser reality.
+- Saved notebook contents can lag behind unsaved edits in the browser.
+- `jupyter console --existing ...` proves local attachment to an existing kernel is possible, but it is a different path from Jupyter Server kernel channels.
+
+## Primary sources
+
+- Jupyter Server REST API: https://jupyter-server.readthedocs.io/en/latest/developers/rest-api.html
+- Jupyter Server WebSocket protocols: https://jupyter-server.readthedocs.io/en/latest/developers/websocket-protocols.html
+- JupyterLab NotebookTracker API: https://jupyterlab.readthedocs.io/en/latest/api/classes/notebook.NotebookTracker.html
+- JupyterLab SessionManager API: https://jupyterlab.readthedocs.io/en/stable/api/classes/services.SessionManager-1.html
+- JupyterLab KernelConnection API: https://jupyterlab.readthedocs.io/en/latest/api/classes/services.KernelConnection.html
+- JupyterLab Workspaces user docs: https://jupyterlab.readthedocs.io/en/4.3.x/user/workspaces.html
+- Jupyter console docs: https://jupyter-console.readthedocs.io/en/stable/
+- Jupyter Server sessions handler source: https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/jupyter_server/services/sessions/handlers.py
+- Jupyter Server kernels handler source: https://raw.githubusercontent.com/jupyter-server/jupyter_server/main/jupyter_server/services/kernels/handlers.py
+- JupyterLab session REST client source: https://raw.githubusercontent.com/jupyterlab/jupyterlab/main/packages/services/src/session/restapi.ts
+- JupyterLab notebook extension source: https://raw.githubusercontent.com/jupyterlab/jupyterlab/main/packages/notebook-extension/src/index.ts

--- a/skills/jupyter-live-kernel/scripts/jupyter_live_kernel.py
+++ b/skills/jupyter-live-kernel/scripts/jupyter_live_kernel.py
@@ -1,0 +1,1920 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, urlencode, urljoin, urlparse, urlunparse
+
+import requests
+import websocket
+from jupyter_client import BlockingKernelClient
+from jupyter_client.connect import find_connection_file
+from jupyter_server.serverapp import list_running_servers
+from nbformat import v4 as nbf
+
+DEFAULT_TIMEOUT = 10.0
+DEFAULT_EXEC_TIMEOUT = 30.0
+
+
+class CommandError(RuntimeError):
+    """Raised when the CLI cannot satisfy a request."""
+
+
+class HTTPCommandError(CommandError):
+    """Raised when an HTTP request completes but returns an error."""
+
+    def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class TransportRetryUnsafeError(CommandError):
+    """Raised when retrying execution could duplicate side effects."""
+
+    def __init__(self, message: str, *, request_sent: bool) -> None:
+        super().__init__(message)
+        self.request_sent = request_sent
+
+
+@dataclass
+class ServerInfo:
+    url: str
+    base_url: str
+    root_dir: str
+    token: str
+    pid: int | None = None
+    port: int | None = None
+    version: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def root_url(self) -> str:
+        base = (self.base_url or "/").strip("/")
+        suffix = f"{base}/" if base else ""
+        return urljoin(self.url if self.url.endswith("/") else f"{self.url}/", suffix)
+
+    @property
+    def ws_root_url(self) -> str:
+        parts = urlparse(self.root_url)
+        scheme = "wss" if parts.scheme == "https" else "ws"
+        return urlunparse((scheme, parts.netloc, parts.path, "", "", ""))
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "url": self.root_url,
+            "port": self.port,
+            "pid": self.pid,
+            "version": self.version,
+            "root_dir": self.root_dir,
+            "token_present": bool(self.token),
+        }
+
+
+@dataclass
+class ProbeResult:
+    reachable: bool
+    auth_ok: bool
+    error: str | None = None
+    sessions_count: int | None = None
+    lab_workspaces_available: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "reachable": self.reachable,
+            "auth_ok": self.auth_ok,
+            "error": self.error,
+            "sessions_count": self.sessions_count,
+            "lab_workspaces_available": self.lab_workspaces_available,
+        }
+
+
+@dataclass
+class ExecutionResult:
+    transport: str
+    kernel_id: str
+    session_id: str | None
+    path: str | None
+    reply: dict[str, Any]
+    events: list[dict[str, Any]]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "transport": self.transport,
+            "kernel_id": self.kernel_id,
+            "session_id": self.session_id,
+            "path": self.path,
+            "reply": self.reply,
+            "events": self.events,
+            "status": self.reply.get("status"),
+        }
+
+
+@dataclass
+class KernelTarget:
+    kernel_id: str
+    kernel_name: str | None
+    session_id: str | None
+    path: str | None
+
+
+@dataclass
+class ExecuteRequest:
+    code: str
+    silent: bool = False
+    store_history: bool = True
+    user_expressions: dict[str, str] = field(default_factory=dict)
+    stop_on_error: bool = True
+
+
+class ServerClient:
+    def __init__(self, server: ServerInfo, timeout: float = DEFAULT_TIMEOUT) -> None:
+        self.server = server
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.session.headers.update({"Accept": "application/json"})
+        if self.server.token:
+            self.session.headers["Authorization"] = f"token {self.server.token}"
+        self._primed = False
+
+    def _prime(self) -> None:
+        if self._primed:
+            return
+        params = {"token": self.server.token} if self.server.token else None
+        try:
+            self.session.get(self.server.root_url, params=params, timeout=self.timeout)
+        except requests.RequestException:
+            self._primed = True
+            return
+        xsrf = self.session.cookies.get("_xsrf")
+        if xsrf:
+            self.session.headers["X-XSRFToken"] = xsrf
+        self._primed = True
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        payload: dict[str, Any] | None = None,
+        timeout: float | None = None,
+        expect_json: bool = True,
+    ) -> Any:
+        self._prime()
+        merged_params = dict(params or {})
+        if self.server.token and "token" not in merged_params:
+            merged_params["token"] = self.server.token
+        url = urljoin(self.server.root_url, path.lstrip("/"))
+        response = self.session.request(
+            method,
+            url,
+            params=merged_params,
+            json=payload,
+            timeout=timeout or self.timeout,
+        )
+        if response.status_code >= 400:
+            snippet = response.text[:400].strip()
+            raise HTTPCommandError(
+                f"{method} {url} failed with {response.status_code}: {snippet}",
+                status_code=response.status_code,
+            )
+        if expect_json:
+            return response.json()
+        return response.text
+
+    def websocket_headers(self) -> list[str]:
+        self._prime()
+        headers: list[str] = []
+        if self.server.token:
+            headers.append(f"Authorization: token {self.server.token}")
+        cookies = self.session.cookies.get_dict()
+        if cookies:
+            headers.append("Cookie: " + "; ".join(f"{key}={value}" for key, value in cookies.items()))
+        xsrf = cookies.get("_xsrf")
+        if xsrf:
+            headers.append(f"X-XSRFToken: {xsrf}")
+        return headers
+
+
+
+def _server_from_raw(raw: dict[str, Any]) -> ServerInfo:
+    return ServerInfo(
+        url=raw["url"],
+        base_url=raw.get("base_url", "/"),
+        root_dir=raw.get("root_dir") or raw.get("notebook_dir") or "",
+        token=raw.get("token", ""),
+        pid=raw.get("pid"),
+        port=raw.get("port"),
+        version=raw.get("version"),
+        raw=raw,
+    )
+
+
+def _running_server_infos() -> list[ServerInfo]:
+    return [_server_from_raw(raw) for raw in list_running_servers()]
+
+
+def discover_servers(timeout: float = DEFAULT_TIMEOUT) -> list[dict[str, Any]]:
+    discovered: list[dict[str, Any]] = []
+    for server in _running_server_infos():
+        probe = probe_server(server, timeout=timeout)
+        discovered.append({"server": server.summary(), "probe": probe.as_dict()})
+    discovered.sort(key=lambda item: (not item["probe"]["reachable"], item["server"]["url"]))
+    return discovered
+
+
+
+def probe_server(server: ServerInfo, timeout: float = DEFAULT_TIMEOUT) -> ProbeResult:
+    client = ServerClient(server, timeout=timeout)
+    try:
+        sessions = client.request("GET", "api/sessions", timeout=timeout)
+    except HTTPCommandError as exc:
+        return ProbeResult(
+            reachable=True,
+            auth_ok=exc.status_code not in {401, 403},
+            error=str(exc),
+        )
+    except requests.RequestException as exc:
+        return ProbeResult(reachable=False, auth_ok=False, error=str(exc))
+
+    lab_available = False
+    try:
+        client.request("GET", "lab/api/workspaces", timeout=timeout)
+        lab_available = True
+    except (CommandError, requests.RequestException):
+        lab_available = False
+
+    return ProbeResult(
+        reachable=True,
+        auth_ok=True,
+        sessions_count=len(sessions) if isinstance(sessions, list) else None,
+        lab_workspaces_available=lab_available,
+    )
+
+
+
+def _select_server(
+    *,
+    server_url: str | None,
+    port: int | None,
+    timeout: float,
+) -> ServerInfo:
+    if server_url or port:
+        for server in _running_server_infos():
+            if port and server.port != port:
+                continue
+            if server_url and server.root_url != server_url:
+                continue
+            probe = probe_server(server, timeout=timeout)
+            if probe.reachable and probe.auth_ok:
+                return server
+            criterion = server_url or f"port {port}"
+            if probe.reachable and not probe.auth_ok:
+                raise CommandError(
+                    f"Jupyter server matched {criterion}, but authentication failed. "
+                    "Use a server with working auth or refresh the server token."
+                )
+        criterion = server_url or f"port {port}"
+        raise CommandError(f"No reachable Jupyter server matched {criterion}.")
+
+    reachable_raw: list[ServerInfo] = []
+    for server in _running_server_infos():
+        probe = probe_server(server, timeout=timeout)
+        if probe.reachable and probe.auth_ok:
+            reachable_raw.append(server)
+
+    if not reachable_raw:
+        raise CommandError("No reachable Jupyter servers with working auth were discovered.")
+    if len(reachable_raw) > 1:
+        urls = ", ".join(server.root_url for server in reachable_raw)
+        raise CommandError(
+            "Multiple reachable Jupyter servers were discovered. "
+            f"Pass --server-url or --port. Candidates: {urls}"
+        )
+    return reachable_raw[0]
+
+
+
+def list_sessions(server: ServerInfo, timeout: float = DEFAULT_TIMEOUT) -> list[dict[str, Any]]:
+    client = ServerClient(server, timeout=timeout)
+    sessions = client.request("GET", "api/sessions")
+    result: list[dict[str, Any]] = []
+    for session in sessions:
+        kernel = session.get("kernel") or {}
+        result.append(
+            {
+                "id": session.get("id"),
+                "path": session.get("path"),
+                "type": session.get("type"),
+                "name": session.get("name"),
+                "kernel": {
+                    "id": kernel.get("id"),
+                    "name": kernel.get("name"),
+                    "execution_state": kernel.get("execution_state"),
+                    "last_activity": kernel.get("last_activity"),
+                    "connections": kernel.get("connections"),
+                },
+            }
+        )
+    return result
+
+
+
+def _extract_notebook_paths(value: Any) -> set[str]:
+    found: set[str] = set()
+    if isinstance(value, dict):
+        for child in value.values():
+            found.update(_extract_notebook_paths(child))
+    elif isinstance(value, list):
+        for child in value:
+            found.update(_extract_notebook_paths(child))
+    elif isinstance(value, str) and value.startswith("notebook:"):
+        found.add(value.split(":", 1)[1])
+    return found
+
+
+def _path_exists_in_server_root(
+    server: ServerInfo,
+    path: str,
+    *,
+    client: ServerClient | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> bool:
+    if server.root_dir and os.path.isdir(server.root_dir):
+        return (Path(server.root_dir) / path).exists()
+
+    client = client or ServerClient(server, timeout=timeout)
+    try:
+        encoded_path = quote(path, safe="/")
+        client.request(
+            "GET",
+            f"api/contents/{encoded_path}",
+            params={"content": 0},
+            timeout=timeout,
+        )
+        return True
+    except (CommandError, requests.RequestException):
+        return False
+
+
+
+def list_workspaces(server: ServerInfo, timeout: float = DEFAULT_TIMEOUT) -> list[dict[str, Any]]:
+    client = ServerClient(server, timeout=timeout)
+    try:
+        payload = client.request("GET", "lab/api/workspaces")
+    except HTTPCommandError as exc:
+        if exc.status_code == 404:
+            return []
+        raise
+
+    values = payload.get("workspaces", {}).get("values", [])
+    result: list[dict[str, Any]] = []
+    for workspace in values:
+        data = workspace.get("data", {})
+        notebooks = sorted(
+            path
+            for path in _extract_notebook_paths(data.get("layout-restorer:data", data))
+            if _path_exists_in_server_root(server, path, client=client, timeout=timeout)
+        )
+        if notebooks:
+            result.append(
+                {
+                    "id": workspace.get("metadata", {}).get("id"),
+                    "notebooks": notebooks,
+                    "raw": workspace,
+                }
+            )
+    return result
+
+
+
+def combined_open_notebooks(server: ServerInfo, timeout: float = DEFAULT_TIMEOUT) -> dict[str, Any]:
+    sessions = [item for item in list_sessions(server, timeout=timeout) if item.get("type") == "notebook"]
+    workspaces = list_workspaces(server, timeout=timeout)
+    combined: dict[str, dict[str, Any]] = {}
+
+    for session in sessions:
+        path = session.get("path")
+        if not path:
+            continue
+        item = combined.setdefault(
+            path,
+            {"path": path, "live": False, "session_ids": [], "kernel_ids": [], "workspace_ids": []},
+        )
+        item["live"] = True
+        if session["id"]:
+            item["session_ids"].append(session["id"])
+        kernel_id = (session.get("kernel") or {}).get("id")
+        if kernel_id:
+            item["kernel_ids"].append(kernel_id)
+
+    for workspace in workspaces:
+        workspace_id = workspace.get("id")
+        for path in workspace.get("notebooks", []):
+            item = combined.setdefault(
+                path,
+                {"path": path, "live": False, "session_ids": [], "kernel_ids": [], "workspace_ids": []},
+            )
+            if workspace_id:
+                item["workspace_ids"].append(workspace_id)
+
+    open_notebooks = []
+    for path in sorted(combined):
+        item = combined[path]
+        item["session_ids"] = sorted(set(item["session_ids"]))
+        item["kernel_ids"] = sorted(set(item["kernel_ids"]))
+        item["workspace_ids"] = sorted(set(item["workspace_ids"]))
+        open_notebooks.append(item)
+
+    return {
+        "server": server.summary(),
+        "sessions": sessions,
+        "workspaces": [{"id": ws["id"], "notebooks": ws["notebooks"]} for ws in workspaces],
+        "open_notebooks": open_notebooks,
+    }
+
+
+
+def get_contents(
+    server: ServerInfo,
+    path: str,
+    *,
+    include_outputs: bool,
+    raw: bool,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    model = _load_notebook_model(server, path, timeout=timeout)
+    if raw:
+        return model
+
+    content = model.get("content") or {}
+    cells = []
+    for index, cell in enumerate(content.get("cells", [])):
+        cells.append(_summarize_cell(cell, index=index, include_outputs=include_outputs))
+
+    return {
+        "path": model.get("path"),
+        "name": model.get("name"),
+        "type": model.get("type"),
+        "last_modified": model.get("last_modified"),
+        "format": model.get("format"),
+        "nbformat": content.get("nbformat"),
+        "nbformat_minor": content.get("nbformat_minor"),
+        "cells": cells,
+    }
+
+
+
+def _load_notebook_model(server: ServerInfo, path: str, timeout: float = DEFAULT_TIMEOUT) -> dict[str, Any]:
+    client = ServerClient(server, timeout=timeout)
+    encoded_path = quote(path, safe="/")
+    model = client.request(
+        "GET",
+        f"api/contents/{encoded_path}",
+        params={"content": 1, "type": "notebook"},
+    )
+    _normalize_notebook_content(model.setdefault("content", {}), notebook_path=path)
+    return model
+
+
+
+def _save_notebook_content(
+    server: ServerInfo,
+    path: str,
+    content: dict[str, Any],
+    timeout: float = DEFAULT_TIMEOUT,
+    expected_last_modified: str | None = None,
+) -> dict[str, Any]:
+    client = ServerClient(server, timeout=timeout)
+    encoded_path = quote(path, safe="/")
+    _normalize_notebook_content(content, notebook_path=path)
+    if expected_last_modified is not None:
+        current = client.request(
+            "GET",
+            f"api/contents/{encoded_path}",
+            params={"content": 0, "type": "notebook"},
+        )
+        if current.get("last_modified") != expected_last_modified:
+            raise CommandError("Notebook changed since it was loaded; reload contents and retry the edit.")
+    return client.request(
+        "PUT",
+        f"api/contents/{encoded_path}",
+        payload={"type": "notebook", "format": "json", "content": content},
+    )
+
+
+
+def _synthetic_cell_id(cell: dict[str, Any], *, notebook_path: str, cell_index: int) -> str:
+    payload = json.dumps(
+        {
+            "path": notebook_path,
+            "index": cell_index,
+            "cell_type": cell.get("cell_type"),
+            "source": cell.get("source", ""),
+            "metadata": cell.get("metadata", {}),
+        },
+        sort_keys=True,
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+    return f"synthetic-{digest}"
+
+
+
+def _ensure_cell_id(cell: dict[str, Any], *, notebook_path: str | None, cell_index: int) -> None:
+    if cell.get("id"):
+        return
+    if notebook_path:
+        cell["id"] = _synthetic_cell_id(cell, notebook_path=notebook_path, cell_index=cell_index)
+        return
+    cell["id"] = uuid.uuid4().hex
+
+
+
+def _normalize_notebook_content(content: dict[str, Any], notebook_path: str | None = None) -> None:
+    content.setdefault("metadata", {})
+    content.setdefault("nbformat", 4)
+    content.setdefault("nbformat_minor", 5)
+    cells = content.setdefault("cells", [])
+    for cell_index, cell in enumerate(cells):
+        source = cell.get("source", "")
+        if isinstance(source, list):
+            cell["source"] = "".join(source)
+        _ensure_cell_id(cell, notebook_path=notebook_path, cell_index=cell_index)
+
+
+
+def _summarize_cell(
+    cell: dict[str, Any],
+    *,
+    index: int,
+    include_outputs: bool,
+) -> dict[str, Any]:
+    summary = {
+        "index": index,
+        "cell_id": cell.get("id"),
+        "cell_type": cell.get("cell_type"),
+        "source": cell.get("source", ""),
+    }
+    if "execution_count" in cell:
+        summary["execution_count"] = cell.get("execution_count")
+    if include_outputs and cell.get("cell_type") == "code":
+        summary["outputs"] = [_summarize_output(output) for output in cell.get("outputs", [])]
+    return summary
+
+
+
+def _resolve_cell_index(
+    cells: list[dict[str, Any]],
+    *,
+    index: int | None,
+    cell_id: str | None,
+) -> int:
+    if index is not None:
+        if index < 0 or index >= len(cells):
+            raise CommandError(f"Cell index {index} is out of range for notebook with {len(cells)} cells.")
+        return index
+    if cell_id is not None:
+        for current_index, cell in enumerate(cells):
+            if cell.get("id") == cell_id:
+                return current_index
+        raise CommandError(f"No cell matched id {cell_id}.")
+    raise CommandError("Pass one of --index or --cell-id.")
+
+
+
+def _build_cell(cell_type: str, source: str) -> dict[str, Any]:
+    if cell_type == "code":
+        return dict(nbf.new_code_cell(source=source))
+    if cell_type == "markdown":
+        return dict(nbf.new_markdown_cell(source=source))
+    if cell_type == "raw":
+        return dict(nbf.new_raw_cell(source=source))
+    raise CommandError(f"Unsupported cell type {cell_type!r}.")
+
+
+
+def edit_cell_source(
+    server: ServerInfo,
+    *,
+    path: str,
+    index: int | None,
+    cell_id: str | None,
+    source: str,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    model = _load_notebook_model(server, path, timeout=timeout)
+    cells = model["content"]["cells"]
+    resolved_index = _resolve_cell_index(cells, index=index, cell_id=cell_id)
+    if cells[resolved_index].get("source", "") == source:
+        return {
+            "path": path,
+            "operation": "replace-source",
+            "changed": False,
+            "cell": _summarize_cell(cells[resolved_index], index=resolved_index, include_outputs=False),
+            "cell_count": len(cells),
+        }
+    cells[resolved_index]["source"] = source
+    _save_notebook_content(server, path, model["content"], timeout=timeout, expected_last_modified=model.get("last_modified"))
+    return {
+        "path": path,
+        "operation": "replace-source",
+        "changed": True,
+        "cell": _summarize_cell(cells[resolved_index], index=resolved_index, include_outputs=False),
+        "cell_count": len(cells),
+    }
+
+
+
+def insert_cell(
+    server: ServerInfo,
+    *,
+    path: str,
+    cell_type: str,
+    source: str,
+    at_index: int,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    model = _load_notebook_model(server, path, timeout=timeout)
+    cells = model["content"]["cells"]
+    if at_index < 0 or at_index > len(cells):
+        raise CommandError(f"Insert index {at_index} is out of range for notebook with {len(cells)} cells.")
+    cell = _build_cell(cell_type, source)
+    cells.insert(at_index, cell)
+    _save_notebook_content(server, path, model["content"], timeout=timeout, expected_last_modified=model.get("last_modified"))
+    return {
+        "path": path,
+        "operation": "insert-cell",
+        "changed": True,
+        "cell": _summarize_cell(cell, index=at_index, include_outputs=False),
+        "cell_count": len(cells),
+    }
+
+
+
+def delete_cell(
+    server: ServerInfo,
+    *,
+    path: str,
+    index: int | None,
+    cell_id: str | None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    model = _load_notebook_model(server, path, timeout=timeout)
+    cells = model["content"]["cells"]
+    resolved_index = _resolve_cell_index(cells, index=index, cell_id=cell_id)
+    removed = cells.pop(resolved_index)
+    _save_notebook_content(server, path, model["content"], timeout=timeout, expected_last_modified=model.get("last_modified"))
+    return {
+        "path": path,
+        "operation": "delete-cell",
+        "changed": True,
+        "deleted_cell": _summarize_cell(removed, index=resolved_index, include_outputs=False),
+        "cell_count": len(cells),
+    }
+
+
+
+def move_cell(
+    server: ServerInfo,
+    *,
+    path: str,
+    index: int | None,
+    cell_id: str | None,
+    to_index: int,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    model = _load_notebook_model(server, path, timeout=timeout)
+    cells = model["content"]["cells"]
+    resolved_index = _resolve_cell_index(cells, index=index, cell_id=cell_id)
+    original_count = len(cells)
+    if to_index < 0 or to_index >= original_count:
+        raise CommandError(f"Target index {to_index} is out of range for notebook with {original_count} cells.")
+    if resolved_index == to_index:
+        return {
+            "path": path,
+            "operation": "move-cell",
+            "changed": False,
+            "from_index": resolved_index,
+            "to_index": to_index,
+            "cell": _summarize_cell(cells[resolved_index], index=resolved_index, include_outputs=False),
+            "cell_count": len(cells),
+        }
+    cell = cells.pop(resolved_index)
+    cells.insert(to_index, cell)
+    _save_notebook_content(server, path, model["content"], timeout=timeout, expected_last_modified=model.get("last_modified"))
+    return {
+        "path": path,
+        "operation": "move-cell",
+        "changed": True,
+        "from_index": resolved_index,
+        "to_index": to_index,
+        "cell": _summarize_cell(cell, index=to_index, include_outputs=False),
+        "cell_count": len(cells),
+    }
+
+
+
+def clear_cell_outputs(
+    server: ServerInfo,
+    *,
+    path: str,
+    index: int | None,
+    cell_id: str | None,
+    all_cells: bool,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    model = _load_notebook_model(server, path, timeout=timeout)
+    cells = model["content"]["cells"]
+    if all_cells or (index is None and cell_id is None):
+        target_indexes = [cell_index for cell_index, cell in enumerate(cells) if cell.get("cell_type") == "code"]
+    else:
+        target_indexes = [_resolve_cell_index(cells, index=index, cell_id=cell_id)]
+
+    changed = False
+    cleared_cells: list[dict[str, Any]] = []
+    for cell_index in target_indexes:
+        cell = cells[cell_index]
+        if cell.get("cell_type") != "code":
+            continue
+        outputs = cell.get("outputs") or []
+        execution_count = cell.get("execution_count")
+        if outputs or execution_count is not None:
+            cell["outputs"] = []
+            cell["execution_count"] = None
+            changed = True
+        cleared_cells.append(_summarize_cell(cell, index=cell_index, include_outputs=False))
+
+    if changed:
+        _save_notebook_content(
+            server,
+            path,
+            model["content"],
+            timeout=timeout,
+            expected_last_modified=model.get("last_modified"),
+        )
+
+    return {
+        "path": path,
+        "operation": "clear-outputs",
+        "changed": changed,
+        "cleared_cell_count": len(cleared_cells),
+        "cells": cleared_cells,
+        "cell_count": len(cells),
+    }
+
+
+def _summarize_output(output: dict[str, Any]) -> dict[str, Any]:
+    output_type = output.get("output_type")
+    if output_type == "stream":
+        return {
+            "output_type": "stream",
+            "name": output.get("name"),
+            "text": output.get("text", ""),
+        }
+    if output_type in {"display_data", "execute_result"}:
+        return {
+            "output_type": output_type,
+            "data": output.get("data", {}),
+            "execution_count": output.get("execution_count"),
+        }
+    if output_type == "error":
+        return {
+            "output_type": "error",
+            "ename": output.get("ename"),
+            "evalue": output.get("evalue"),
+            "traceback": output.get("traceback", []),
+        }
+    return output
+
+
+
+def _resolve_session(
+    server: ServerInfo,
+    *,
+    path: str | None,
+    session_id: str | None,
+    kernel_id: str | None,
+    timeout: float,
+) -> dict[str, Any]:
+    sessions = list_sessions(server, timeout=timeout)
+    if session_id:
+        for session in sessions:
+            if session.get("id") == session_id:
+                _validate_target_consistency(session, path=path, kernel_id=kernel_id)
+                return session
+        raise CommandError(f"No session matched id {session_id}.")
+    if kernel_id:
+        for session in sessions:
+            if (session.get("kernel") or {}).get("id") == kernel_id:
+                _validate_target_consistency(session, path=path, kernel_id=kernel_id)
+                return session
+        raise CommandError(f"No live session matched kernel id {kernel_id}.")
+    if path:
+        matches = [session for session in sessions if session.get("path") == path]
+        if not matches:
+            raise CommandError(f"No live session matched notebook path {path}.")
+        if len(matches) > 1:
+            ids = ", ".join(session["id"] for session in matches if session.get("id"))
+            raise CommandError(
+                f"Multiple live sessions matched notebook path {path}. Pass --session-id. Sessions: {ids}"
+            )
+        return matches[0]
+    raise CommandError("Pass one of --path, --session-id, or --kernel-id.")
+
+
+def _validate_target_consistency(
+    session: dict[str, Any],
+    *,
+    path: str | None,
+    kernel_id: str | None,
+) -> None:
+    session_path = session.get("path")
+    session_kernel_id = (session.get("kernel") or {}).get("id")
+    if path and session_path and session_path != path:
+        raise CommandError(
+            f"Conflicting live target selectors: session resolves to path {session_path!r}, not {path!r}."
+        )
+    if kernel_id and session_kernel_id and session_kernel_id != kernel_id:
+        raise CommandError(
+            f"Conflicting live target selectors: session resolves to kernel {session_kernel_id!r}, not {kernel_id!r}."
+        )
+
+
+def _resolve_kernel_target(
+    server: ServerInfo,
+    *,
+    path: str | None,
+    session_id: str | None,
+    kernel_id: str | None,
+    timeout: float,
+) -> KernelTarget:
+    session = _resolve_session(
+        server,
+        path=path,
+        session_id=session_id,
+        kernel_id=kernel_id,
+        timeout=timeout,
+    )
+    resolved_kernel_id = kernel_id or (session.get("kernel") or {}).get("id")
+    if not resolved_kernel_id:
+        raise CommandError("Could not determine a kernel id for execution.")
+    return KernelTarget(
+        kernel_id=resolved_kernel_id,
+        kernel_name=(session.get("kernel") or {}).get("name"),
+        session_id=session.get("id"),
+        path=session.get("path"),
+    )
+
+
+def _execute_request(
+    server: ServerInfo,
+    *,
+    path: str | None,
+    session_id: str | None,
+    kernel_id: str | None,
+    request: ExecuteRequest,
+    transport: str,
+    timeout: float,
+) -> ExecutionResult:
+    target = _resolve_kernel_target(
+        server,
+        path=path,
+        session_id=session_id,
+        kernel_id=kernel_id,
+        timeout=timeout,
+    )
+    return _execute_request_with_target(
+        server,
+        target=target,
+        request=request,
+        transport=transport,
+        timeout=timeout,
+    )
+
+
+def _execute_request_with_target(
+    server: ServerInfo,
+    *,
+    target: KernelTarget,
+    request: ExecuteRequest,
+    transport: str,
+    timeout: float,
+) -> ExecutionResult:
+
+    attempts: list[str] = [transport]
+    if transport == "auto":
+        attempts = ["websocket", "zmq"]
+
+    last_error: Exception | None = None
+    for attempt in attempts:
+        try:
+            if attempt == "websocket":
+                result = _execute_via_websocket(
+                    server,
+                    kernel_id=target.kernel_id,
+                    session_id=target.session_id,
+                    path=target.path,
+                    request=request,
+                    timeout=timeout,
+                )
+            elif attempt == "zmq":
+                result = _execute_via_zmq(
+                    kernel_id=target.kernel_id,
+                    session_id=target.session_id,
+                    path=target.path,
+                    request=request,
+                    timeout=timeout,
+                )
+            else:
+                raise CommandError(f"Unknown transport {attempt!r}.")
+            return result
+        except TransportRetryUnsafeError as exc:
+            if transport == "auto" and exc.request_sent:
+                raise CommandError(
+                    "Websocket execution may already have reached the kernel, so auto fallback was skipped "
+                    "to avoid running the code twice."
+                ) from exc
+            last_error = exc
+            continue
+        except (CommandError, requests.RequestException, OSError, RuntimeError) as exc:
+            last_error = exc
+            continue
+
+    raise CommandError(f"Execution failed for all transports: {last_error}")
+
+
+def execute_code(
+    server: ServerInfo,
+    *,
+    path: str | None,
+    session_id: str | None,
+    kernel_id: str | None,
+    code: str,
+    transport: str,
+    timeout: float,
+) -> dict[str, Any]:
+    return _execute_request(
+        server,
+        path=path,
+        session_id=session_id,
+        kernel_id=kernel_id,
+        request=ExecuteRequest(code=code),
+        transport=transport,
+        timeout=timeout,
+    ).as_dict()
+
+
+
+def _ws_url(server: ServerInfo, kernel_id: str) -> str:
+    base = urljoin(server.ws_root_url, f"api/kernels/{kernel_id}/channels")
+    if not server.token:
+        return base
+    separator = "&" if "?" in base else "?"
+    return f"{base}{separator}{urlencode({'token': server.token})}"
+
+
+
+def _message_type(msg: dict[str, Any]) -> str | None:
+    return msg.get("msg_type") or (msg.get("header") or {}).get("msg_type")
+
+
+
+def _message_parent_id(msg: dict[str, Any]) -> str | None:
+    parent = msg.get("parent_header") or {}
+    return parent.get("msg_id")
+
+
+def _belongs_to_execution(msg: dict[str, Any], msg_id: str) -> bool:
+    return _message_parent_id(msg) == msg_id
+
+
+
+def _summarize_channel_message(msg: dict[str, Any]) -> dict[str, Any] | None:
+    msg_type = _message_type(msg)
+    content = msg.get("content") or {}
+    if msg_type == "stream":
+        return {"type": "stream", "name": content.get("name"), "text": content.get("text", "")}
+    if msg_type == "execute_result":
+        return {
+            "type": "execute_result",
+            "execution_count": content.get("execution_count"),
+            "data": content.get("data", {}),
+            "metadata": content.get("metadata", {}),
+        }
+    if msg_type == "display_data":
+        return {"type": "display_data", "data": content.get("data", {}), "metadata": content.get("metadata", {})}
+    if msg_type == "error":
+        return {
+            "type": "error",
+            "ename": content.get("ename"),
+            "evalue": content.get("evalue"),
+            "traceback": content.get("traceback", []),
+        }
+    if msg_type == "execute_input":
+        return {
+            "type": "execute_input",
+            "execution_count": content.get("execution_count"),
+            "code": content.get("code", ""),
+        }
+    if msg_type == "status":
+        return {"type": "status", "execution_state": content.get("execution_state")}
+    return None
+
+
+
+def _execute_via_websocket(
+    server: ServerInfo,
+    *,
+    kernel_id: str,
+    session_id: str | None,
+    path: str | None,
+    request: ExecuteRequest,
+    timeout: float,
+) -> ExecutionResult:
+    client = ServerClient(server, timeout=timeout)
+    msg_id = uuid.uuid4().hex
+    shell_session_id = uuid.uuid4().hex
+    payload = {
+        "header": {
+            "msg_id": msg_id,
+            "username": "codex",
+            "session": shell_session_id,
+            "msg_type": "execute_request",
+            "version": "5.3",
+        },
+        "parent_header": {},
+        "metadata": {},
+        "content": {
+            "code": request.code,
+            "silent": request.silent,
+            "store_history": request.store_history,
+            "user_expressions": request.user_expressions,
+            "allow_stdin": False,
+            "stop_on_error": request.stop_on_error,
+        },
+        "channel": "shell",
+        "buffers": [],
+    }
+
+    reply: dict[str, Any] | None = None
+    events: list[dict[str, Any]] = []
+    deadline = time.time() + timeout
+    request_sent = False
+    ws = None
+    try:
+        ws = websocket.create_connection(
+            _ws_url(server, kernel_id),
+            header=client.websocket_headers(),
+            timeout=timeout,
+        )
+        ws.send(json.dumps(payload))
+        request_sent = True
+
+        while time.time() < deadline:
+            raw = ws.recv()
+            msg = json.loads(raw)
+            if not _belongs_to_execution(msg, msg_id):
+                continue
+            summary = _summarize_channel_message(msg)
+            if summary is not None:
+                events.append(summary)
+            msg_type = _message_type(msg)
+            if msg_type == "execute_reply":
+                reply = msg.get("content", {})
+            if msg_type == "status" and (msg.get("content") or {}).get("execution_state") == "idle" and reply:
+                break
+        else:
+            raise CommandError("Timed out waiting for kernel execution to finish over websocket.")
+    except Exception as exc:
+        raise TransportRetryUnsafeError(_sanitize_error_text(str(exc), server_token=server.token), request_sent=request_sent) from exc
+    finally:
+        if ws is not None:
+            ws.close()
+
+    return ExecutionResult(
+        transport="websocket",
+        kernel_id=kernel_id,
+        session_id=session_id,
+        path=path,
+        reply=reply or {},
+        events=events,
+    )
+
+
+
+def _execute_via_zmq(
+    *,
+    kernel_id: str,
+    session_id: str | None,
+    path: str | None,
+    request: ExecuteRequest,
+    timeout: float,
+) -> ExecutionResult:
+    connection_file = find_connection_file(f"kernel-{kernel_id}.json")
+    client = BlockingKernelClient(connection_file=connection_file)
+    client.load_connection_file(connection_file)
+    client.start_channels()
+    events: list[dict[str, Any]] = []
+    try:
+        client.wait_for_ready(timeout=timeout)
+        reply_msg = client.execute_interactive(
+            request.code,
+            silent=request.silent,
+            store_history=request.store_history,
+            user_expressions=request.user_expressions,
+            allow_stdin=False,
+            stop_on_error=request.stop_on_error,
+            timeout=timeout,
+            output_hook=lambda msg: _collect_output(events, msg),
+        )
+    finally:
+        client.stop_channels()
+
+    return ExecutionResult(
+        transport="zmq",
+        kernel_id=kernel_id,
+        session_id=session_id,
+        path=path,
+        reply=(reply_msg.get("content") or {}),
+        events=events,
+    )
+
+
+
+def _collect_output(events: list[dict[str, Any]], msg: dict[str, Any]) -> None:
+    summary = _summarize_channel_message(msg)
+    if summary is not None:
+        events.append(summary)
+
+
+
+def _get_kernel_model(server: ServerInfo, kernel_id: str, timeout: float = DEFAULT_TIMEOUT) -> dict[str, Any]:
+    client = ServerClient(server, timeout=timeout)
+    return client.request("GET", f"api/kernels/{quote(kernel_id, safe='')}", timeout=timeout)
+
+
+def _wait_for_kernel_idle(server: ServerInfo, kernel_id: str, timeout: float) -> dict[str, Any]:
+    deadline = time.time() + timeout
+    last_state: str | None = None
+    while time.time() < deadline:
+        try:
+            model = _get_kernel_model(server, kernel_id, timeout=timeout)
+        except HTTPCommandError as exc:
+            if exc.status_code == 404:
+                time.sleep(0.2)
+                continue
+            raise
+        last_state = model.get("execution_state")
+        if last_state == "idle":
+            return model
+        time.sleep(0.2)
+    raise CommandError(
+        f"Timed out waiting for kernel {kernel_id} to become idle after restart. Last state: {last_state!r}."
+    )
+
+
+def restart_kernel(
+    server: ServerInfo,
+    *,
+    path: str | None,
+    session_id: str | None,
+    kernel_id: str | None,
+    timeout: float,
+) -> dict[str, Any]:
+    target = _resolve_kernel_target(
+        server,
+        path=path,
+        session_id=session_id,
+        kernel_id=kernel_id,
+        timeout=timeout,
+    )
+    client = ServerClient(server, timeout=timeout)
+    client.request("POST", f"api/kernels/{quote(target.kernel_id, safe='')}/restart", timeout=timeout)
+    model = _wait_for_kernel_idle(server, target.kernel_id, timeout=timeout)
+    return {
+        "operation": "restart-kernel",
+        "kernel_id": target.kernel_id,
+        "kernel_name": target.kernel_name,
+        "session_id": target.session_id,
+        "path": target.path,
+        "kernel": {
+            "id": model.get("id"),
+            "name": model.get("name"),
+            "execution_state": model.get("execution_state"),
+            "last_activity": model.get("last_activity"),
+            "connections": model.get("connections"),
+        },
+    }
+
+
+def _require_notebook_session(target: KernelTarget, feature: str) -> None:
+    if not target.path:
+        raise CommandError(f"{feature} requires a notebook path.")
+    if not target.session_id:
+        raise CommandError(f"{feature} requires a live notebook session, not just a bare kernel id.")
+
+
+def _bounded_positive_int(value: int, *, name: str, maximum: int) -> int:
+    if value < 1:
+        raise CommandError(f"{name} must be at least 1.")
+    if value > maximum:
+        raise CommandError(f"{name} must be at most {maximum}.")
+    return value
+
+
+def _source_preview(source: str, limit: int = 120) -> str:
+    single_line = " ".join(source.split())
+    if len(single_line) <= limit:
+        return single_line
+    return f"{single_line[: limit - 3]}..."
+
+
+def run_all_cells(
+    server: ServerInfo,
+    *,
+    path: str | None,
+    session_id: str | None,
+    kernel_id: str | None,
+    transport: str,
+    timeout: float,
+) -> dict[str, Any]:
+    target = _resolve_kernel_target(
+        server,
+        path=path,
+        session_id=session_id,
+        kernel_id=kernel_id,
+        timeout=timeout,
+    )
+    _require_notebook_session(target, "Run-all")
+    notebook_path = path or target.path
+
+    model = _load_notebook_model(server, notebook_path, timeout=timeout)
+    snapshot_sha256 = hashlib.sha256(json.dumps(model["content"], sort_keys=True).encode("utf-8")).hexdigest()
+    results: list[dict[str, Any]] = []
+    executed_cell_count = 0
+    skipped_cell_count = 0
+    overall_status = "ok"
+    failed_cell: dict[str, Any] | None = None
+
+    for cell_index, cell in enumerate(model["content"]["cells"]):
+        if cell.get("cell_type") != "code":
+            continue
+        source = cell.get("source", "")
+        if not source.strip():
+            skipped_cell_count += 1
+            results.append(
+                {
+                    "index": cell_index,
+                    "cell_id": cell.get("id"),
+                    "status": "skipped",
+                    "reason": "empty-source",
+                    "source_preview": _source_preview(source),
+                }
+            )
+            continue
+
+        executed_cell_count += 1
+        result = _execute_request_with_target(
+            server,
+            target=target,
+            request=ExecuteRequest(code=source),
+            transport=transport,
+            timeout=timeout,
+        ).as_dict()
+        cell_result = {
+            "index": cell_index,
+            "cell_id": cell.get("id"),
+            "source_preview": _source_preview(source),
+            "status": result.get("status"),
+            "transport": result.get("transport"),
+            "reply": result.get("reply"),
+            "events": result.get("events"),
+        }
+        results.append(cell_result)
+        if result.get("status") != "ok":
+            overall_status = "error"
+            failed_cell = cell_result
+            break
+
+    return {
+        "operation": "run-all",
+        "path": notebook_path,
+        "kernel_id": target.kernel_id,
+        "kernel_name": target.kernel_name,
+        "session_id": target.session_id,
+        "snapshot_last_modified": model.get("last_modified"),
+        "snapshot_sha256": snapshot_sha256,
+        "transport_requested": transport,
+        "timeout_per_cell_seconds": timeout,
+        "status": overall_status,
+        "executed_cell_count": executed_cell_count,
+        "skipped_cell_count": skipped_cell_count,
+        "failed_cell": failed_cell,
+        "cells": results,
+        "note": "Run-all executes against the live kernel for verification and does not persist notebook outputs.",
+    }
+
+
+def restart_and_run_all(
+    server: ServerInfo,
+    *,
+    path: str | None,
+    session_id: str | None,
+    kernel_id: str | None,
+    transport: str,
+    timeout: float,
+) -> dict[str, Any]:
+    target = _resolve_kernel_target(
+        server,
+        path=path,
+        session_id=session_id,
+        kernel_id=kernel_id,
+        timeout=timeout,
+    )
+    _require_notebook_session(target, "Restart-run-all")
+    restart = restart_kernel(
+        server,
+        path=target.path,
+        session_id=target.session_id,
+        kernel_id=target.kernel_id,
+        timeout=timeout,
+    )
+    run_all = run_all_cells(
+        server,
+        path=target.path,
+        session_id=target.session_id,
+        kernel_id=target.kernel_id,
+        transport=transport,
+        timeout=timeout,
+    )
+    return {
+        "operation": "restart-run-all",
+        "restart": restart,
+        "run_all": run_all,
+        "note": "Restart-run-all is explicit verification mode; prefer incremental execute/edit unless the user asked for a fresh run.",
+    }
+
+
+def _parse_text_plain_literal(value: str) -> Any:
+    try:
+        return ast.literal_eval(value)
+    except (ValueError, SyntaxError):
+        return value
+
+
+def _user_expression_value(reply: dict[str, Any], name: str) -> Any:
+    user_expressions = reply.get("user_expressions") or {}
+    expression_result = user_expressions.get(name)
+    if not expression_result:
+        raise CommandError(f"Kernel did not return a value for user expression {name!r}.")
+    if expression_result.get("status") != "ok":
+        raise CommandError(f"User expression {name!r} failed: {expression_result}")
+    data = expression_result.get("data") or {}
+    if "application/json" in data:
+        return data["application/json"]
+    if "text/plain" in data:
+        return _parse_text_plain_literal(data["text/plain"])
+    return expression_result
+
+
+def _sanitize_error_text(text: str, *, server_token: str | None = None) -> str:
+    redacted = re.sub(r'([?&]token=)([^&\\s]+)', r'\1[REDACTED]', text)
+    if server_token:
+        redacted = redacted.replace(server_token, "[REDACTED]")
+    return redacted
+
+
+def _python_variable_list_expression(*, limit: int, include_private: bool, include_callables: bool) -> str:
+    private_filter = "True" if include_private else "not name.startswith('_')"
+    callable_filter = "True" if include_callables else "not callable(value)"
+    excluded = ("In", "Out", "exit", "quit", "get_ipython")
+    return (
+        "[{'name': name, "
+        "'type': type(value).__name__, "
+        "'module': type(value).__module__} "
+        "for name, value in sorted(globals().items()) "
+        f"if name not in {excluded!r} "
+        f"and ({private_filter}) "
+        f"and ({callable_filter}) "
+        "and type(value).__name__ != 'module']"
+        f"[:{limit}]"
+    )
+
+
+def _python_variable_preview_expression(name: str, *, max_chars: int) -> str:
+    return (
+        """
+(
+lambda _name, _limit:
+    None if _name not in globals() else
+    (lambda _value, _simple: {
+        'name': _name,
+        'type': type(_value).__name__,
+        'module': type(_value).__module__,
+        'preview': (
+            _value[:_limit] if isinstance(_value, str) else
+            _value.decode('utf-8', 'replace')[:_limit] if isinstance(_value, bytes) else
+            _value if isinstance(_value, (type(None), bool, int, float)) else
+            repr(_value)[:_limit] if isinstance(_value, complex) else
+            {'kind': type(_value).__name__, 'length': len(_value), 'items': [_simple(item) for item in list(_value)[:5]]} if isinstance(_value, (list, tuple, set)) else
+            {'kind': 'dict', 'length': len(_value), 'items': [{'key': _simple(key), 'value': _simple(value)} for key, value in list(_value.items())[:5]]} if isinstance(_value, dict) else
+            f'<{type(_value).__module__}.{type(_value).__name__}>'
+        )
+    })(
+        globals()[_name],
+        lambda _item: (
+            _item[:_limit] if isinstance(_item, str) else
+            _item.decode('utf-8', 'replace')[:_limit] if isinstance(_item, bytes) else
+            _item if isinstance(_item, (type(None), bool, int, float)) else
+            repr(_item)[:_limit] if isinstance(_item, complex) else
+            f'<{type(_item).__module__}.{type(_item).__name__}>'
+        )
+    )
+)(%r, %d)
+"""
+        % (name, max_chars)
+    ).strip()
+
+
+def _ensure_python_kernel(target: KernelTarget, feature: str) -> None:
+    if target.kernel_name and "python" in target.kernel_name.lower():
+        return
+    raise CommandError(f"{feature} currently supports Python kernels only. Resolved kernel: {target.kernel_name!r}.")
+
+
+def list_variables(
+    server: ServerInfo,
+    *,
+    path: str | None,
+    session_id: str | None,
+    kernel_id: str | None,
+    transport: str,
+    timeout: float,
+    limit: int,
+    include_private: bool,
+    include_callables: bool,
+) -> dict[str, Any]:
+    limit = _bounded_positive_int(limit, name="limit", maximum=100)
+    target = _resolve_kernel_target(
+        server,
+        path=path,
+        session_id=session_id,
+        kernel_id=kernel_id,
+        timeout=timeout,
+    )
+    _ensure_python_kernel(target, "Variable listing")
+    result = _execute_request(
+        server,
+        path=target.path,
+        session_id=target.session_id,
+        kernel_id=target.kernel_id,
+        request=ExecuteRequest(
+            code="",
+            silent=True,
+            store_history=False,
+            user_expressions={
+                "codex_variables": _python_variable_list_expression(
+                    limit=limit,
+                    include_private=include_private,
+                    include_callables=include_callables,
+                )
+            },
+        ),
+        transport=transport,
+        timeout=timeout,
+    ).as_dict()
+    variables = _user_expression_value(result.get("reply") or {}, "codex_variables")
+    return {
+        "operation": "variables-list",
+        "kernel_id": target.kernel_id,
+        "kernel_name": target.kernel_name,
+        "session_id": target.session_id,
+        "path": target.path,
+        "transport": result.get("transport"),
+        "limit": limit,
+        "variables": variables,
+        "note": "Variable listing uses bounded Python-kernel introspection and does not persist notebook state.",
+    }
+
+
+def preview_variable(
+    server: ServerInfo,
+    *,
+    path: str | None,
+    session_id: str | None,
+    kernel_id: str | None,
+    transport: str,
+    timeout: float,
+    name: str,
+    max_chars: int,
+) -> dict[str, Any]:
+    max_chars = _bounded_positive_int(max_chars, name="max-chars", maximum=2000)
+    target = _resolve_kernel_target(
+        server,
+        path=path,
+        session_id=session_id,
+        kernel_id=kernel_id,
+        timeout=timeout,
+    )
+    _ensure_python_kernel(target, "Variable preview")
+    result = _execute_request(
+        server,
+        path=target.path,
+        session_id=target.session_id,
+        kernel_id=target.kernel_id,
+        request=ExecuteRequest(
+            code="",
+            silent=True,
+            store_history=False,
+            user_expressions={
+                "codex_variable": _python_variable_preview_expression(name, max_chars=max_chars)
+            },
+        ),
+        transport=transport,
+        timeout=timeout,
+    ).as_dict()
+    payload = _user_expression_value(result.get("reply") or {}, "codex_variable")
+    if payload is None:
+        raise CommandError(f"No live variable matched name {name!r}.")
+    return {
+        "operation": "variable-preview",
+        "kernel_id": target.kernel_id,
+        "kernel_name": target.kernel_name,
+        "session_id": target.session_id,
+        "path": target.path,
+        "transport": result.get("transport"),
+        "variable": payload,
+        "note": "Variable preview is bounded and avoids arbitrary repr calls for non-scalar objects.",
+    }
+
+
+def _read_text_argument(value: str | None, file_path: str | None, purpose: str) -> str:
+    if value is not None:
+        return value
+    if file_path:
+        return Path(file_path).read_text(encoding="utf-8")
+    if not sys.stdin.isatty():
+        return sys.stdin.read()
+    raise CommandError(f"Provide {purpose} with --{purpose}, --{purpose}-file, or stdin.")
+
+
+
+def _read_code_argument(code: str | None, code_file: str | None) -> str:
+    return _read_text_argument(code, code_file, "code")
+
+
+
+def _read_source_argument(source: str | None, source_file: str | None) -> str:
+    return _read_text_argument(source, source_file, "source")
+
+
+
+def _print(data: Any, compact: bool) -> None:
+    if compact:
+        print(json.dumps(data, separators=(",", ":"), sort_keys=True))
+        return
+    print(json.dumps(data, indent=2, sort_keys=True))
+
+
+
+def _add_server_selection(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--server-url")
+    parser.add_argument("--port", type=int)
+
+
+
+def _add_live_target_selection(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--path")
+    parser.add_argument("--session-id")
+    parser.add_argument("--kernel-id")
+
+
+def _add_cell_selector(parser: argparse.ArgumentParser, *, required: bool = True) -> None:
+    group = parser.add_mutually_exclusive_group(required=required)
+    group.add_argument("--index", type=int)
+    group.add_argument("--cell-id")
+
+
+
+def _resolve_insert_index(args: argparse.Namespace) -> int:
+    if args.at_index is not None:
+        return args.at_index
+    if args.before is not None:
+        return args.before
+    if args.after is not None:
+        return args.after + 1
+    raise CommandError("Pass one of --at-index, --before, or --after.")
+
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Inspect live Jupyter servers and execute code in running kernels.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    servers_parser = subparsers.add_parser("servers", help="List discovered running Jupyter servers.")
+    servers_parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    servers_parser.add_argument("--compact", action="store_true")
+
+    notebooks_parser = subparsers.add_parser(
+        "notebooks", help="List live notebook sessions plus notebook tabs discovered from JupyterLab workspaces."
+    )
+    _add_server_selection(notebooks_parser)
+    notebooks_parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    notebooks_parser.add_argument("--compact", action="store_true")
+
+    contents_parser = subparsers.add_parser("contents", help="Fetch saved notebook contents through the Contents API.")
+    _add_server_selection(contents_parser)
+    contents_parser.add_argument("--path", required=True)
+    contents_parser.add_argument("--include-outputs", action="store_true")
+    contents_parser.add_argument("--raw", action="store_true")
+    contents_parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    contents_parser.add_argument("--compact", action="store_true")
+
+    execute_parser = subparsers.add_parser("execute", help="Execute code incrementally in a live notebook kernel.")
+    _add_server_selection(execute_parser)
+    _add_live_target_selection(execute_parser)
+    execute_parser.add_argument("--code")
+    execute_parser.add_argument("--code-file")
+    execute_parser.add_argument("--transport", choices=["auto", "websocket", "zmq"], default="auto")
+    execute_parser.add_argument("--timeout", type=float, default=DEFAULT_EXEC_TIMEOUT)
+    execute_parser.add_argument("--compact", action="store_true")
+
+    restart_parser = subparsers.add_parser("restart", help="Restart a live notebook kernel.")
+    _add_server_selection(restart_parser)
+    _add_live_target_selection(restart_parser)
+    restart_parser.add_argument("--timeout", type=float, default=DEFAULT_EXEC_TIMEOUT)
+    restart_parser.add_argument("--compact", action="store_true")
+
+    run_all_parser = subparsers.add_parser(
+        "run-all",
+        help="Execute all notebook code cells against the live kernel without persisting outputs.",
+    )
+    _add_server_selection(run_all_parser)
+    _add_live_target_selection(run_all_parser)
+    run_all_parser.add_argument("--transport", choices=["auto", "websocket", "zmq"], default="auto")
+    run_all_parser.add_argument("--timeout", type=float, default=DEFAULT_EXEC_TIMEOUT)
+    run_all_parser.add_argument("--compact", action="store_true")
+
+    restart_run_all_parser = subparsers.add_parser(
+        "restart-run-all",
+        help="Restart the live kernel and then run all notebook code cells for verification.",
+    )
+    _add_server_selection(restart_run_all_parser)
+    _add_live_target_selection(restart_run_all_parser)
+    restart_run_all_parser.add_argument("--transport", choices=["auto", "websocket", "zmq"], default="auto")
+    restart_run_all_parser.add_argument("--timeout", type=float, default=DEFAULT_EXEC_TIMEOUT)
+    restart_run_all_parser.add_argument("--compact", action="store_true")
+
+    edit_parser = subparsers.add_parser("edit", help="Edit saved notebook cells through the Contents API.")
+    _add_server_selection(edit_parser)
+    edit_parser.add_argument("--path", required=True)
+    edit_parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    edit_subparsers = edit_parser.add_subparsers(dest="edit_command", required=True)
+
+    replace_parser = edit_subparsers.add_parser("replace-source", help="Replace the source of an existing cell.")
+    _add_cell_selector(replace_parser)
+    replace_parser.add_argument("--source")
+    replace_parser.add_argument("--source-file")
+    replace_parser.add_argument("--compact", action="store_true")
+
+    insert_parser = edit_subparsers.add_parser("insert", help="Insert a new cell into the notebook.")
+    location_group = insert_parser.add_mutually_exclusive_group(required=True)
+    location_group.add_argument("--at-index", type=int)
+    location_group.add_argument("--before", type=int)
+    location_group.add_argument("--after", type=int)
+    insert_parser.add_argument("--cell-type", choices=["code", "markdown", "raw"], required=True)
+    insert_parser.add_argument("--source")
+    insert_parser.add_argument("--source-file")
+    insert_parser.add_argument("--compact", action="store_true")
+
+    delete_parser = edit_subparsers.add_parser("delete", help="Delete a cell from the notebook.")
+    _add_cell_selector(delete_parser)
+    delete_parser.add_argument("--compact", action="store_true")
+
+    move_parser = edit_subparsers.add_parser("move", help="Move a cell to a different index.")
+    _add_cell_selector(move_parser)
+    move_parser.add_argument("--to-index", type=int, required=True)
+    move_parser.add_argument("--compact", action="store_true")
+
+    clear_outputs_parser = edit_subparsers.add_parser(
+        "clear-outputs",
+        help="Clear saved outputs and execution counts for code cells.",
+    )
+    clear_outputs_group = clear_outputs_parser.add_mutually_exclusive_group(required=False)
+    clear_outputs_group.add_argument("--all", action="store_true")
+    clear_outputs_group.add_argument("--index", type=int)
+    clear_outputs_group.add_argument("--cell-id")
+    clear_outputs_parser.add_argument("--compact", action="store_true")
+
+    variables_parser = subparsers.add_parser(
+        "variables",
+        help="Inspect live Python-kernel variables with bounded previews.",
+    )
+    _add_server_selection(variables_parser)
+    _add_live_target_selection(variables_parser)
+    variables_parser.add_argument("--transport", choices=["auto", "websocket", "zmq"], default="auto")
+    variables_parser.add_argument("--timeout", type=float, default=DEFAULT_EXEC_TIMEOUT)
+    variables_subparsers = variables_parser.add_subparsers(dest="variables_command", required=True)
+
+    variables_list_parser = variables_subparsers.add_parser("list", help="List live variables in the kernel.")
+    variables_list_parser.add_argument("--limit", type=int, default=25)
+    variables_list_parser.add_argument("--include-private", action="store_true")
+    variables_list_parser.add_argument("--include-callables", action="store_true")
+    variables_list_parser.add_argument("--compact", action="store_true")
+
+    variables_preview_parser = variables_subparsers.add_parser(
+        "preview",
+        help="Show a bounded preview of a live variable in the kernel.",
+    )
+    variables_preview_parser.add_argument("--name", required=True)
+    variables_preview_parser.add_argument("--max-chars", type=int, default=400)
+    variables_preview_parser.add_argument("--compact", action="store_true")
+
+    return parser
+
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "servers":
+            _print({"servers": discover_servers(timeout=args.timeout)}, args.compact)
+            return 0
+
+        server = _select_server(server_url=args.server_url, port=args.port, timeout=args.timeout)
+
+        if args.command == "notebooks":
+            _print(combined_open_notebooks(server, timeout=args.timeout), args.compact)
+            return 0
+
+        if args.command == "contents":
+            _print(
+                get_contents(
+                    server,
+                    args.path,
+                    include_outputs=args.include_outputs,
+                    raw=args.raw,
+                    timeout=args.timeout,
+                ),
+                args.compact,
+            )
+            return 0
+
+        if args.command == "execute":
+            code = _read_code_argument(args.code, args.code_file)
+            _print(
+                execute_code(
+                    server,
+                    path=args.path,
+                    session_id=args.session_id,
+                    kernel_id=args.kernel_id,
+                    code=code,
+                    transport=args.transport,
+                    timeout=args.timeout,
+                ),
+                args.compact,
+            )
+            return 0
+
+        if args.command == "restart":
+            _print(
+                restart_kernel(
+                    server,
+                    path=args.path,
+                    session_id=args.session_id,
+                    kernel_id=args.kernel_id,
+                    timeout=args.timeout,
+                ),
+                args.compact,
+            )
+            return 0
+
+        if args.command == "run-all":
+            result = run_all_cells(
+                server,
+                path=args.path,
+                session_id=args.session_id,
+                kernel_id=args.kernel_id,
+                transport=args.transport,
+                timeout=args.timeout,
+            )
+            _print(result, args.compact)
+            return 0 if result.get("status") == "ok" else 1
+
+        if args.command == "restart-run-all":
+            result = restart_and_run_all(
+                server,
+                path=args.path,
+                session_id=args.session_id,
+                kernel_id=args.kernel_id,
+                transport=args.transport,
+                timeout=args.timeout,
+            )
+            _print(result, args.compact)
+            return 0 if (result.get("run_all") or {}).get("status") == "ok" else 1
+
+        if args.command == "edit":
+            if args.edit_command == "replace-source":
+                result = edit_cell_source(
+                    server,
+                    path=args.path,
+                    index=args.index,
+                    cell_id=args.cell_id,
+                    source=_read_source_argument(args.source, args.source_file),
+                    timeout=args.timeout,
+                )
+            elif args.edit_command == "insert":
+                result = insert_cell(
+                    server,
+                    path=args.path,
+                    cell_type=args.cell_type,
+                    source=_read_source_argument(args.source, args.source_file),
+                    at_index=_resolve_insert_index(args),
+                    timeout=args.timeout,
+                )
+            elif args.edit_command == "delete":
+                result = delete_cell(
+                    server,
+                    path=args.path,
+                    index=args.index,
+                    cell_id=args.cell_id,
+                    timeout=args.timeout,
+                )
+            elif args.edit_command == "move":
+                result = move_cell(
+                    server,
+                    path=args.path,
+                    index=args.index,
+                    cell_id=args.cell_id,
+                    to_index=args.to_index,
+                    timeout=args.timeout,
+                )
+            elif args.edit_command == "clear-outputs":
+                result = clear_cell_outputs(
+                    server,
+                    path=args.path,
+                    index=args.index,
+                    cell_id=args.cell_id,
+                    all_cells=args.all,
+                    timeout=args.timeout,
+                )
+            else:
+                raise CommandError(f"Unknown edit command {args.edit_command!r}.")
+            _print(result, args.compact)
+            return 0
+
+        if args.command == "variables":
+            if args.variables_command == "list":
+                result = list_variables(
+                    server,
+                    path=args.path,
+                    session_id=args.session_id,
+                    kernel_id=args.kernel_id,
+                    transport=args.transport,
+                    timeout=args.timeout,
+                    limit=args.limit,
+                    include_private=args.include_private,
+                    include_callables=args.include_callables,
+                )
+            elif args.variables_command == "preview":
+                result = preview_variable(
+                    server,
+                    path=args.path,
+                    session_id=args.session_id,
+                    kernel_id=args.kernel_id,
+                    transport=args.transport,
+                    timeout=args.timeout,
+                    name=args.name,
+                    max_chars=args.max_chars,
+                )
+            else:
+                raise CommandError(f"Unknown variables command {args.variables_command!r}.")
+            _print(result, args.compact)
+            return 0
+    except CommandError as exc:
+        token = server.token if "server" in locals() else None
+        print(json.dumps({"error": _sanitize_error_text(str(exc), server_token=token)}, indent=2), file=sys.stderr)
+        return 1
+    except Exception as exc:  # pragma: no cover - defensive CLI surface
+        token = server.token if "server" in locals() else None
+        message = _sanitize_error_text(f"Unexpected error: {exc}", server_token=token)
+        print(json.dumps({"error": message}, indent=2), file=sys.stderr)
+        return 1
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_jupyter_live_kernel.py
+++ b/tests/test_jupyter_live_kernel.py
@@ -1,0 +1,1518 @@
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import socket
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+import unittest
+import uuid
+from pathlib import Path
+from unittest import mock
+
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / 'skills/jupyter-live-kernel/scripts/jupyter_live_kernel.py'
+TOKEN = 'testtoken'
+NOTEBOOK_PATH = 'demo.ipynb'
+WORKSPACE_ID = f'codex-{uuid.uuid4().hex[:8]}'
+TINY_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z1ioAAAAASUVORK5CYII='
+
+SPEC = importlib.util.spec_from_file_location('jupyter_live_kernel', SCRIPT_PATH)
+assert SPEC and SPEC.loader
+JUPYTER_LIVE_KERNEL = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = JUPYTER_LIVE_KERNEL
+SPEC.loader.exec_module(JUPYTER_LIVE_KERNEL)
+
+
+class JupyterLiveKernelUnitTests(unittest.TestCase):
+    def test_sanitize_error_text_redacts_token(self) -> None:
+        message = 'websocket failed for ws://127.0.0.1:9999/api/kernels/id/channels?token=secret-token'
+        redacted = JUPYTER_LIVE_KERNEL._sanitize_error_text(message, server_token='secret-token')
+        self.assertNotIn('secret-token', redacted)
+        self.assertIn('token=[REDACTED]', redacted)
+
+    def test_explicit_server_selection_requires_working_auth(self) -> None:
+        server = JUPYTER_LIVE_KERNEL.ServerInfo(
+            url='http://127.0.0.1:9999',
+            base_url='/',
+            root_dir='.',
+            token='bad-token',
+            port=9999,
+        )
+        with (
+            mock.patch.object(JUPYTER_LIVE_KERNEL, '_running_server_infos', return_value=[server]),
+            mock.patch.object(
+                JUPYTER_LIVE_KERNEL,
+                'probe_server',
+                return_value=JUPYTER_LIVE_KERNEL.ProbeResult(
+                    reachable=True,
+                    auth_ok=False,
+                    error='forbidden',
+                ),
+            ),
+        ):
+            with self.assertRaises(JUPYTER_LIVE_KERNEL.CommandError) as exc_info:
+                JUPYTER_LIVE_KERNEL._select_server(server_url=None, port=9999, timeout=5)
+
+        self.assertIn('authentication failed', str(exc_info.exception))
+
+    def test_auto_transport_will_not_retry_after_unsafe_websocket_failure(self) -> None:
+        server = JUPYTER_LIVE_KERNEL.ServerInfo(
+            url='http://127.0.0.1:9999',
+            base_url='/',
+            root_dir='.',
+            token='',
+        )
+        session = {'id': 'session-1', 'path': NOTEBOOK_PATH, 'kernel': {'id': 'kernel-1'}}
+
+        with (
+            mock.patch.object(JUPYTER_LIVE_KERNEL, '_resolve_session', return_value=session),
+            mock.patch.object(
+                JUPYTER_LIVE_KERNEL,
+                '_execute_via_websocket',
+                side_effect=JUPYTER_LIVE_KERNEL.TransportRetryUnsafeError(
+                    'socket closed after send',
+                    request_sent=True,
+                ),
+            ),
+            mock.patch.object(JUPYTER_LIVE_KERNEL, '_execute_via_zmq') as execute_via_zmq,
+        ):
+            with self.assertRaises(JUPYTER_LIVE_KERNEL.CommandError) as exc_info:
+                JUPYTER_LIVE_KERNEL.execute_code(
+                    server,
+                    path=NOTEBOOK_PATH,
+                    session_id=None,
+                    kernel_id=None,
+                    code='print(1)',
+                    transport='auto',
+                    timeout=5,
+                )
+
+        execute_via_zmq.assert_not_called()
+        self.assertIn('auto fallback was skipped', str(exc_info.exception))
+
+    def test_message_must_match_parent_header(self) -> None:
+        msg_id = 'expected-msg-id'
+        self.assertTrue(
+            JUPYTER_LIVE_KERNEL._belongs_to_execution(
+                {'parent_header': {'msg_id': msg_id}},
+                msg_id,
+            )
+        )
+        self.assertFalse(
+            JUPYTER_LIVE_KERNEL._belongs_to_execution(
+                {'parent_header': {}},
+                msg_id,
+            )
+        )
+
+    def test_probe_server_distinguishes_auth_failure_from_unreachable(self) -> None:
+        server = JUPYTER_LIVE_KERNEL.ServerInfo(
+            url='http://127.0.0.1:9999',
+            base_url='/',
+            root_dir='.',
+            token='bad-token',
+        )
+        with mock.patch.object(
+            JUPYTER_LIVE_KERNEL.ServerClient,
+            'request',
+            side_effect=JUPYTER_LIVE_KERNEL.HTTPCommandError('forbidden', status_code=403),
+        ):
+            probe = JUPYTER_LIVE_KERNEL.probe_server(server)
+
+        self.assertTrue(probe.reachable)
+        self.assertFalse(probe.auth_ok)
+        self.assertEqual(probe.error, 'forbidden')
+
+    def test_save_notebook_rejects_stale_last_modified(self) -> None:
+        server = JUPYTER_LIVE_KERNEL.ServerInfo(
+            url='http://127.0.0.1:9999',
+            base_url='/',
+            root_dir='.',
+            token='',
+        )
+        client = mock.Mock()
+        client.request.return_value = {'last_modified': 'newer'}
+        with mock.patch.object(JUPYTER_LIVE_KERNEL, 'ServerClient', return_value=client):
+            with self.assertRaises(JUPYTER_LIVE_KERNEL.CommandError) as exc_info:
+                JUPYTER_LIVE_KERNEL._save_notebook_content(
+                    server,
+                    'demo.ipynb',
+                    {'cells': [], 'metadata': {}, 'nbformat': 4, 'nbformat_minor': 5},
+                    expected_last_modified='older',
+                )
+
+        self.assertIn('Notebook changed since it was loaded', str(exc_info.exception))
+        self.assertEqual(client.request.call_count, 1)
+
+
+class JupyterLiveKernelIntegrationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.root_dir = tempfile.TemporaryDirectory(prefix='codex-jupyter-skill.')
+        cls.log_path = Path(tempfile.mkstemp(prefix='codex-jupyter-lab.', suffix='.log')[1])
+        cls.log_handle = cls.log_path.open('w', encoding='utf-8')
+        cls.port = cls._find_free_port()
+        cls.base_url = f'http://127.0.0.1:{cls.port}'
+        cls.headers = {'Authorization': f'token {TOKEN}'}
+        cls.proc = cls._start_server()
+        cls._wait_for_server_ready()
+        cls._create_notebook()
+        session = cls._create_session()
+        cls.session_id = session['id']
+        cls.kernel_id = session['kernel']['id']
+        cls._seed_workspace()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        try:
+            cls._delete_sessions()
+        finally:
+            if hasattr(cls, 'proc') and cls.proc.poll() is None:
+                cls.proc.terminate()
+                try:
+                    cls.proc.wait(timeout=20)
+                except subprocess.TimeoutExpired:
+                    cls.proc.kill()
+            if hasattr(cls, 'log_handle') and not cls.log_handle.closed:
+                cls.log_handle.close()
+            if hasattr(cls, 'root_dir'):
+                cls.root_dir.cleanup()
+            if hasattr(cls, 'log_path') and cls.log_path.exists():
+                cls.log_path.unlink(missing_ok=True)
+
+    @classmethod
+    def _start_server(cls) -> subprocess.Popen[str]:
+        return subprocess.Popen(
+            [
+                'jupyter',
+                'lab',
+                '--no-browser',
+                f'--IdentityProvider.token={TOKEN}',
+                '--ServerApp.password=',
+                f'--ServerApp.port={cls.port}',
+                '--ServerApp.port_retries=50',
+                f'--ServerApp.root_dir={cls.root_dir.name}',
+            ],
+            stdout=cls.log_handle,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+    @staticmethod
+    def _find_free_port() -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(('127.0.0.1', 0))
+            sock.listen(1)
+            return int(sock.getsockname()[1])
+
+    @classmethod
+    def _runtime_server(cls) -> dict[str, object] | None:
+        for server in JUPYTER_LIVE_KERNEL.list_running_servers():
+            root_dir = server.get('root_dir') or server.get('notebook_dir')
+            server_pid = server.get('pid')
+            if root_dir == cls.root_dir.name and (server_pid is None or server_pid == cls.proc.pid):
+                return server
+        return None
+
+    @classmethod
+    def _wait_for_server_ready(cls) -> None:
+        deadline = time.time() + 60
+        while time.time() < deadline:
+            if cls.proc.poll() is not None:
+                raise RuntimeError(cls.log_path.read_text(encoding='utf-8'))
+            runtime_server = cls._runtime_server()
+            if runtime_server:
+                cls.port = int(runtime_server['port'])
+                cls.base_url = str(runtime_server['url']).rstrip('/')
+            try:
+                response = requests.get(
+                    f'{cls.base_url}/api/contents',
+                    params={'token': TOKEN},
+                    headers=cls.headers,
+                    timeout=1,
+                )
+                if response.status_code == 200:
+                    return
+            except requests.RequestException:
+                pass
+            time.sleep(0.25)
+        raise RuntimeError(f'JupyterLab did not become ready.\n{cls.log_path.read_text(encoding="utf-8")}')
+
+    @classmethod
+    def _api_request(cls, method: str, path: str, **kwargs):
+        params = dict(kwargs.pop('params', {}))
+        params.setdefault('token', TOKEN)
+        response = requests.request(
+            method,
+            f'{cls.base_url}{path}',
+            headers=cls.headers,
+            params=params,
+            timeout=10,
+            **kwargs,
+        )
+        response.raise_for_status()
+        if response.text:
+            return response.json()
+        return None
+
+    @classmethod
+    def _notebook_payload(
+        cls,
+        cells: list[dict[str, object]],
+        *,
+        metadata: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        return {
+            'type': 'notebook',
+            'format': 'json',
+            'content': {
+                'cells': cells,
+                'metadata': metadata or {},
+                'nbformat': 4,
+                'nbformat_minor': 5,
+            },
+        }
+
+    @classmethod
+    def _put_notebook(
+        cls,
+        path: str,
+        cells: list[dict[str, object]],
+        *,
+        metadata: dict[str, object] | None = None,
+    ) -> None:
+        cls._api_request('PUT', f'/api/contents/{path}', json=cls._notebook_payload(cells, metadata=metadata))
+
+    @staticmethod
+    def _code_cell(
+        cell_id: str,
+        source: str,
+        *,
+        execution_count: int | None = None,
+        outputs: list[dict[str, object]] | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        return {
+            'id': cell_id,
+            'cell_type': 'code',
+            'execution_count': execution_count,
+            'metadata': metadata or {},
+            'outputs': outputs or [],
+            'source': source,
+        }
+
+    @staticmethod
+    def _markdown_cell(
+        cell_id: str,
+        source: str,
+        *,
+        attachments: dict[str, object] | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        cell = {
+            'id': cell_id,
+            'cell_type': 'markdown',
+            'metadata': metadata or {},
+            'source': source,
+        }
+        if attachments:
+            cell['attachments'] = attachments
+        return cell
+
+    @staticmethod
+    def _raw_cell(
+        cell_id: str,
+        source: str,
+        *,
+        metadata: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        return {
+            'id': cell_id,
+            'cell_type': 'raw',
+            'metadata': metadata or {},
+            'source': source,
+        }
+
+    @classmethod
+    def _create_notebook(cls) -> None:
+        cls._put_notebook(
+            NOTEBOOK_PATH,
+            [
+                {
+                    'id': 'demo-code',
+                    'cell_type': 'code',
+                    'execution_count': None,
+                    'metadata': {},
+                    'outputs': [],
+                    'source': 'a = 40\na + 1',
+                },
+                {
+                    'id': 'demo-markdown',
+                    'cell_type': 'markdown',
+                    'metadata': {},
+                    'source': '# Demo notebook',
+                },
+            ],
+        )
+
+    @classmethod
+    def _create_session(cls) -> dict[str, object]:
+        payload = {
+            'path': NOTEBOOK_PATH,
+            'type': 'notebook',
+            'name': '',
+            'kernel': {'name': 'python3'},
+        }
+        return cls._api_request('POST', '/api/sessions', json=payload)
+
+    @classmethod
+    def _create_session_for_path(cls, path: str) -> dict[str, object]:
+        payload = {
+            'path': path,
+            'type': 'notebook',
+            'name': '',
+            'kernel': {'name': 'python3'},
+        }
+        return cls._api_request('POST', '/api/sessions', json=payload)
+
+    @classmethod
+    def _seed_workspace(cls) -> None:
+        payload = {
+            'data': {
+                'layout-restorer:data': {
+                    'main': {
+                        'dock': {'type': 'tab-area', 'widgets': [f'notebook:{NOTEBOOK_PATH}']},
+                        'current': f'notebook:{NOTEBOOK_PATH}',
+                    }
+                }
+            },
+            'metadata': {'id': WORKSPACE_ID},
+        }
+        cls._api_request('PUT', f'/lab/api/workspaces/{WORKSPACE_ID}', json=payload)
+
+    @classmethod
+    def _delete_sessions(cls) -> None:
+        sessions = cls._api_request('GET', '/api/sessions')
+        for session in sessions:
+            requests.delete(
+                f'{cls.base_url}/api/sessions/{session["id"]}',
+                params={'token': TOKEN},
+                headers=cls.headers,
+                timeout=10,
+            )
+
+    def _run_cli(self, *args: str) -> dict[str, object]:
+        completed = self._run_cli_completed(*args)
+        if completed.returncode != 0:
+            self.fail(f'CLI failed\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}')
+        return json.loads(completed.stdout)
+
+    def _run_cli_completed(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def _run_cli_error(self, *args: str) -> dict[str, object]:
+        completed = self._run_cli_completed(*args)
+        if completed.returncode == 0:
+            self.fail(f'CLI unexpectedly succeeded\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}')
+        payload = completed.stdout.strip() or completed.stderr.strip()
+        return json.loads(payload)
+
+    @staticmethod
+    def _execute_result_texts(payload: dict[str, object]) -> list[str]:
+        events = payload.get('events') or []
+        return [event['data']['text/plain'] for event in events if event['type'] == 'execute_result']
+
+    @classmethod
+    def _last_execute_result_value(cls, payload: dict[str, object]) -> object:
+        results = cls._execute_result_texts(payload)
+        if not results:
+            raise AssertionError(f'No execute_result events found in payload: {payload}')
+        return ast.literal_eval(results[-1])
+
+    def test_servers_discovers_live_server(self) -> None:
+        payload = self._run_cli('servers', '--compact')
+        matches = [item for item in payload['servers'] if item['server'].get('port') == self.port]
+        self.assertEqual(len(matches), 1)
+        self.assertTrue(matches[0]['probe']['reachable'])
+        self.assertTrue(matches[0]['probe']['lab_workspaces_available'])
+
+    def test_notebooks_combines_sessions_and_workspaces(self) -> None:
+        payload = self._run_cli('notebooks', '--port', str(self.port), '--compact')
+        notebook = next(item for item in payload['open_notebooks'] if item['path'] == NOTEBOOK_PATH)
+        self.assertTrue(notebook['live'])
+        self.assertIn(self.session_id, notebook['session_ids'])
+        self.assertIn(self.kernel_id, notebook['kernel_ids'])
+        self.assertIn(WORKSPACE_ID, notebook['workspace_ids'])
+
+    def test_contents_returns_saved_cells(self) -> None:
+        payload = self._run_cli('contents', '--port', str(self.port), '--path', NOTEBOOK_PATH, '--compact')
+        self.assertEqual(payload['path'], NOTEBOOK_PATH)
+        self.assertEqual(len(payload['cells']), 2)
+        self.assertEqual(payload['cells'][0]['cell_id'], 'demo-code')
+        self.assertIn('a = 40', payload['cells'][0]['source'])
+        self.assertEqual(payload['cells'][1]['cell_type'], 'markdown')
+
+    def _contents(self, path: str) -> dict[str, object]:
+        return self._run_cli('contents', '--port', str(self.port), '--path', path, '--compact')
+
+    def _contents_with_outputs(self, path: str) -> dict[str, object]:
+        return self._run_cli(
+            'contents',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--include-outputs',
+            '--compact',
+        )
+
+    def _raw_contents(self, path: str) -> dict[str, object]:
+        return self._run_cli(
+            'contents',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--raw',
+            '--compact',
+        )
+
+    def test_edit_replace_source_by_cell_id(self) -> None:
+        path = f'replace-{uuid.uuid4().hex[:8]}.ipynb'
+        self._put_notebook(
+            path,
+            [
+                {
+                    'id': 'replace-code',
+                    'cell_type': 'code',
+                    'execution_count': None,
+                    'metadata': {},
+                    'outputs': [],
+                    'source': 'value = 1',
+                },
+                {
+                    'id': 'replace-md',
+                    'cell_type': 'markdown',
+                    'metadata': {},
+                    'source': 'keep me',
+                },
+            ],
+        )
+
+        payload = self._run_cli(
+            'edit',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            'replace-source',
+            '--cell-id',
+            'replace-code',
+            '--source',
+            'value = 2\nvalue',
+            '--compact',
+        )
+        self.assertTrue(payload['changed'])
+        contents = self._contents(path)
+        self.assertEqual(contents['cells'][0]['cell_id'], 'replace-code')
+        self.assertEqual(contents['cells'][0]['source'], 'value = 2\nvalue')
+
+    def test_legacy_notebook_without_ids_can_be_retargeted_by_reported_cell_id(self) -> None:
+        path = f'legacy-{uuid.uuid4().hex[:8]}.ipynb'
+        self._put_notebook(
+            path,
+            [
+                {
+                    'cell_type': 'markdown',
+                    'metadata': {},
+                    'source': 'legacy',
+                }
+            ],
+        )
+
+        contents = self._contents(path)
+        legacy_id = contents['cells'][0]['cell_id']
+        self.assertTrue(legacy_id)
+
+        payload = self._run_cli(
+            'edit',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            'replace-source',
+            '--cell-id',
+            legacy_id,
+            '--source',
+            'modernized',
+            '--compact',
+        )
+        self.assertTrue(payload['changed'])
+
+        contents = self._contents(path)
+        self.assertEqual(contents['cells'][0]['cell_id'], legacy_id)
+        self.assertEqual(contents['cells'][0]['source'], 'modernized')
+
+    def test_edit_insert_delete_and_move_cells(self) -> None:
+        path = f'edit-{uuid.uuid4().hex[:8]}.ipynb'
+        self._put_notebook(
+            path,
+            [
+                {
+                    'id': 'cell-one',
+                    'cell_type': 'markdown',
+                    'metadata': {},
+                    'source': 'one',
+                },
+                {
+                    'id': 'cell-two',
+                    'cell_type': 'markdown',
+                    'metadata': {},
+                    'source': 'two',
+                },
+                {
+                    'id': 'cell-three',
+                    'cell_type': 'markdown',
+                    'metadata': {},
+                    'source': 'three',
+                },
+            ],
+        )
+
+        inserted = self._run_cli(
+            'edit',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            'insert',
+            '--after',
+            '0',
+            '--cell-type',
+            'code',
+            '--source',
+            'inserted = True',
+            '--compact',
+        )
+        self.assertTrue(inserted['changed'])
+        inserted_id = inserted['cell']['cell_id']
+
+        moved = self._run_cli(
+            'edit',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            'move',
+            '--cell-id',
+            'cell-three',
+            '--to-index',
+            '0',
+            '--compact',
+        )
+        self.assertTrue(moved['changed'])
+
+        deleted = self._run_cli(
+            'edit',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            'delete',
+            '--cell-id',
+            inserted_id,
+            '--compact',
+        )
+        self.assertTrue(deleted['changed'])
+
+        contents = self._contents(path)
+        self.assertEqual([cell['cell_id'] for cell in contents['cells']], ['cell-three', 'cell-one', 'cell-two'])
+        self.assertEqual([cell['source'] for cell in contents['cells']], ['three', 'one', 'two'])
+
+    def test_edit_clear_outputs_resets_saved_outputs(self) -> None:
+        path = f'clear-{uuid.uuid4().hex[:8]}.ipynb'
+        self._put_notebook(
+            path,
+            [
+                {
+                    'id': 'code-cell',
+                    'cell_type': 'code',
+                    'execution_count': 7,
+                    'metadata': {},
+                    'outputs': [{'output_type': 'stream', 'name': 'stdout', 'text': 'stale\n'}],
+                    'source': 'print("fresh")',
+                },
+                {
+                    'id': 'markdown-cell',
+                    'cell_type': 'markdown',
+                    'metadata': {},
+                    'source': 'keep',
+                },
+            ],
+        )
+
+        payload = self._run_cli(
+            'edit',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            'clear-outputs',
+            '--all',
+            '--compact',
+        )
+        self.assertTrue(payload['changed'])
+        self.assertEqual(payload['cleared_cell_count'], 1)
+
+        contents = self._contents_with_outputs(path)
+        self.assertEqual(contents['cells'][0]['outputs'], [])
+        self.assertIsNone(contents['cells'][0]['execution_count'])
+        self.assertEqual(contents['cells'][0]['source'], 'print("fresh")')
+
+    def test_edit_operations_preserve_messy_notebook_structure(self) -> None:
+        path = f'messy-{uuid.uuid4().hex[:8]}.ipynb'
+        notebook_metadata = {
+            'kernelspec': {'display_name': 'Python 3', 'language': 'python', 'name': 'python3'},
+            'language_info': {'name': 'python', 'version': '3.14'},
+            'codex_demo': {'scenario': 'messy-notebook', 'audience': 'back-row'},
+        }
+        rich_html = (
+            '<table><thead><tr><th>region</th><th>revenue</th></tr></thead>'
+            '<tbody><tr><td>north</td><td>100</td></tr><tr><td>south</td><td>90</td></tr></tbody></table>'
+        )
+        self._put_notebook(
+            path,
+            [
+                self._markdown_cell(
+                    'intro-md',
+                    '## Live notebook demo\n![hero](attachment:hero.png)',
+                    attachments={'hero.png': {'image/png': TINY_PNG_BASE64}},
+                    metadata={'tags': ['intro']},
+                ),
+                self._code_cell(
+                    'setup-summary',
+                    'summary = {"rows": 2, "regions": ["north", "south"]}\nsummary',
+                    execution_count=3,
+                    outputs=[
+                        {
+                            'output_type': 'execute_result',
+                            'execution_count': 3,
+                            'data': {
+                                'text/plain': "{'rows': 2, 'regions': ['north', 'south']}",
+                                'application/json': {'rows': 2, 'regions': ['north', 'south']},
+                            },
+                            'metadata': {},
+                        }
+                    ],
+                    metadata={'tags': ['setup', 'expensive']},
+                ),
+                self._code_cell(
+                    'df-preview',
+                    'sales_df.head()',
+                    execution_count=4,
+                    outputs=[
+                        {
+                            'output_type': 'display_data',
+                            'data': {
+                                'text/plain': '  region  revenue\n0  north      100\n1  south       90',
+                                'text/html': rich_html,
+                            },
+                            'metadata': {},
+                        }
+                    ],
+                    metadata={'tags': ['table']},
+                ),
+                self._code_cell(
+                    'plot-output',
+                    'plot_sales()',
+                    execution_count=5,
+                    outputs=[
+                        {
+                            'output_type': 'display_data',
+                            'data': {
+                                'text/plain': '<Figure size 640x480 with 1 Axes>',
+                                'image/png': TINY_PNG_BASE64,
+                            },
+                            'metadata': {},
+                        }
+                    ],
+                    metadata={'tags': ['plot']},
+                ),
+                self._raw_cell(
+                    'speaker-notes',
+                    'Do not show this raw notes cell to the audience.',
+                    metadata={'format': 'text/plain'},
+                ),
+                self._markdown_cell(
+                    'analysis-md',
+                    'The next cell contains a bug we will patch live.',
+                    metadata={'tags': ['narrative']},
+                ),
+                self._code_cell(
+                    'buggy-analysis',
+                    'metric = profit / cost\nmetric',
+                    metadata={'tags': ['bug']},
+                ),
+            ],
+            metadata=notebook_metadata,
+        )
+
+        fixed_source = 'metric = profit / revenue\nmetric'
+        replaced = self._run_cli(
+            'edit',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            'replace-source',
+            '--cell-id',
+            'buggy-analysis',
+            '--source',
+            fixed_source,
+            '--compact',
+        )
+        self.assertTrue(replaced['changed'])
+
+        inserted = self._run_cli(
+            'edit',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            'insert',
+            '--after',
+            '3',
+            '--cell-type',
+            'markdown',
+            '--source',
+            '### Patch applied\nUse the live kernel state for fast iteration.',
+            '--compact',
+        )
+        inserted_id = inserted['cell']['cell_id']
+        self.assertEqual(inserted['cell']['cell_type'], 'markdown')
+
+        moved = self._run_cli(
+            'edit',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            'move',
+            '--cell-id',
+            inserted_id,
+            '--to-index',
+            '5',
+            '--compact',
+        )
+        self.assertTrue(moved['changed'])
+
+        deleted = self._run_cli(
+            'edit',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            'delete',
+            '--cell-id',
+            'speaker-notes',
+            '--compact',
+        )
+        self.assertTrue(deleted['changed'])
+
+        cleared = self._run_cli(
+            'edit',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            'clear-outputs',
+            '--cell-id',
+            'df-preview',
+            '--compact',
+        )
+        self.assertTrue(cleared['changed'])
+        self.assertEqual(cleared['cleared_cell_count'], 1)
+
+        raw_contents = self._raw_contents(path)
+        content = raw_contents['content']
+        cells_by_id = {cell['id']: cell for cell in content['cells']}
+        ordered_ids = [cell['id'] for cell in content['cells']]
+
+        self.assertEqual(content['metadata']['codex_demo']['scenario'], 'messy-notebook')
+        self.assertEqual(cells_by_id['intro-md']['attachments']['hero.png']['image/png'], TINY_PNG_BASE64)
+        self.assertEqual(cells_by_id['plot-output']['outputs'][0]['data']['image/png'], TINY_PNG_BASE64)
+        self.assertEqual(cells_by_id['plot-output']['outputs'][0]['data']['text/plain'], '<Figure size 640x480 with 1 Axes>')
+        self.assertEqual(cells_by_id['df-preview']['outputs'], [])
+        self.assertIsNone(cells_by_id['df-preview']['execution_count'])
+        self.assertEqual(cells_by_id['setup-summary']['outputs'][0]['data']['application/json']['rows'], 2)
+        self.assertEqual(cells_by_id['buggy-analysis']['source'], fixed_source)
+        self.assertNotIn('speaker-notes', cells_by_id)
+        self.assertIn(inserted_id, cells_by_id)
+        self.assertIn('Patch applied', cells_by_id[inserted_id]['source'])
+        self.assertLess(ordered_ids.index(inserted_id), ordered_ids.index('analysis-md'))
+
+    def test_demo_workflow_reuses_live_kernel_state_after_patching_a_buggy_cell(self) -> None:
+        path = f'demo-workflow-{uuid.uuid4().hex[:8]}.ipynb'
+        setup_source = textwrap.dedent(
+            """
+            import sqlite3
+            import time
+            import uuid
+
+            cold_setup_runs = globals().get("cold_setup_runs", 0) + 1
+            setup_id = globals().get("setup_id") or uuid.uuid4().hex[:8]
+            time.sleep(0.05)
+
+            conn = sqlite3.connect(":memory:")
+            cur = conn.cursor()
+            cur.execute("create table sales(region text, revenue real, cost real)")
+            cur.executemany(
+                "insert into sales values (?, ?, ?)",
+                [
+                    ("north", 100.0, 80.0),
+                    ("south", 90.0, 60.0),
+                    ("west", 120.0, 50.0),
+                ],
+            )
+            conn.commit()
+            """
+        ).strip()
+        baseline_source = textwrap.dedent(
+            """
+            row_count = cur.execute("select count(*) from sales").fetchone()[0]
+            row_count
+            """
+        ).strip()
+        buggy_source = textwrap.dedent(
+            """
+            totals = cur.execute("select sum(revenue), sum(cost) from sales").fetchone()
+            margin = round((totals[0] - totals[1]) / totals[1], 3)
+            margin
+            """
+        ).strip()
+        fixed_source = textwrap.dedent(
+            """
+            totals = cur.execute("select sum(revenue), sum(cost) from sales").fetchone()
+            margin = round((totals[0] - totals[1]) / totals[0], 3)
+            margin
+            """
+        ).strip()
+        validation_source = textwrap.dedent(
+            """
+            {
+                "margin": margin,
+                "cold_setup_runs": cold_setup_runs,
+                "row_count": cur.execute("select count(*) from sales").fetchone()[0],
+                "setup_id": setup_id,
+            }
+            """
+        ).strip()
+
+        self._put_notebook(
+            path,
+            [
+                self._markdown_cell(
+                    'demo-intro',
+                    '# Demo\nPatch the downstream metric without rebuilding the in-memory database.',
+                    metadata={'tags': ['intro']},
+                ),
+                self._code_cell('expensive-setup', setup_source, metadata={'tags': ['setup', 'expensive']}),
+                self._code_cell('baseline-check', baseline_source, metadata={'tags': ['baseline']}),
+                self._code_cell('buggy-margin', buggy_source, metadata={'tags': ['bug']}),
+            ],
+            metadata={'codex_demo': {'scenario': 'live-kernel-iteration'}},
+        )
+        self._create_session_for_path(path)
+
+        initial_contents = self._contents(path)
+        self.assertEqual([cell['cell_id'] for cell in initial_contents['cells']], ['demo-intro', 'expensive-setup', 'baseline-check', 'buggy-margin'])
+
+        self._run_cli(
+            'execute',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--transport',
+            'zmq',
+            '--code',
+            setup_source,
+            '--compact',
+        )
+
+        variables = self._run_cli(
+            'variables',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--transport',
+            'zmq',
+            'list',
+            '--compact',
+        )
+        variable_names = {item['name'] for item in variables['variables']}
+        self.assertIn('cur', variable_names)
+        self.assertIn('setup_id', variable_names)
+        self.assertIn('cold_setup_runs', variable_names)
+
+        setup_id_preview = self._run_cli(
+            'variables',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--transport',
+            'zmq',
+            'preview',
+            '--name',
+            'setup_id',
+            '--compact',
+        )
+        self.assertEqual(setup_id_preview['variable']['type'], 'str')
+        self.assertIsInstance(setup_id_preview['variable']['preview'], str)
+        self.assertTrue(setup_id_preview['variable']['preview'])
+
+        cursor_preview = self._run_cli(
+            'variables',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--transport',
+            'zmq',
+            'preview',
+            '--name',
+            'cur',
+            '--compact',
+        )
+        self.assertEqual(cursor_preview['variable']['type'], 'Cursor')
+        self.assertEqual(cursor_preview['variable']['preview'], '<sqlite3.Cursor>')
+
+        baseline = self._run_cli(
+            'execute',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--transport',
+            'zmq',
+            '--code',
+            baseline_source,
+            '--compact',
+        )
+        self.assertEqual(self._last_execute_result_value(baseline), 3)
+
+        buggy = self._run_cli(
+            'execute',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--transport',
+            'zmq',
+            '--code',
+            buggy_source,
+            '--compact',
+        )
+        self.assertEqual(self._last_execute_result_value(buggy), 0.632)
+
+        replaced = self._run_cli(
+            'edit',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            'replace-source',
+            '--cell-id',
+            'buggy-margin',
+            '--source',
+            fixed_source,
+            '--compact',
+        )
+        self.assertTrue(replaced['changed'])
+
+        edited_contents = self._contents(path)
+        updated_bug_cell = next(cell for cell in edited_contents['cells'] if cell['cell_id'] == 'buggy-margin')
+        self.assertEqual(updated_bug_cell['source'], fixed_source)
+
+        fixed = self._run_cli(
+            'execute',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--transport',
+            'zmq',
+            '--code',
+            updated_bug_cell['source'],
+            '--compact',
+        )
+        self.assertEqual(self._last_execute_result_value(fixed), 0.387)
+
+        validation = self._run_cli(
+            'execute',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--transport',
+            'zmq',
+            '--code',
+            validation_source,
+            '--compact',
+        )
+        self.assertEqual(
+            self._last_execute_result_value(validation),
+            {
+                'margin': 0.387,
+                'cold_setup_runs': 1,
+                'row_count': 3,
+                'setup_id': setup_id_preview['variable']['preview'],
+            },
+        )
+
+        verification = self._run_cli(
+            'restart-run-all',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--transport',
+            'zmq',
+            '--compact',
+        )
+        self.assertEqual(verification['run_all']['status'], 'ok')
+
+        post_verify = self._run_cli(
+            'execute',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--transport',
+            'zmq',
+            '--code',
+            '{"margin": margin, "cold_setup_runs": cold_setup_runs}',
+            '--compact',
+        )
+        self.assertEqual(self._last_execute_result_value(post_verify), {'margin': 0.387, 'cold_setup_runs': 1})
+
+    def test_execute_over_websocket(self) -> None:
+        payload = self._run_cli(
+            'execute',
+            '--port',
+            str(self.port),
+            '--path',
+            NOTEBOOK_PATH,
+            '--transport',
+            'websocket',
+            '--code',
+            'value = 100\nprint("ws ok")\nvalue + 23',
+            '--compact',
+        )
+        self.assertEqual(payload['status'], 'ok')
+        self.assertEqual(payload['transport'], 'websocket')
+        texts = [event['text'] for event in payload['events'] if event['type'] == 'stream']
+        results = [event['data']['text/plain'] for event in payload['events'] if event['type'] == 'execute_result']
+        self.assertIn('ws ok\n', texts)
+        self.assertIn('123', results)
+
+    def test_execute_over_zmq(self) -> None:
+        payload = self._run_cli(
+            'execute',
+            '--port',
+            str(self.port),
+            '--path',
+            NOTEBOOK_PATH,
+            '--transport',
+            'zmq',
+            '--code',
+            'value = 7\nprint("zmq ok")\nvalue * 6',
+            '--compact',
+        )
+        self.assertEqual(payload['status'], 'ok')
+        self.assertEqual(payload['transport'], 'zmq')
+        texts = [event['text'] for event in payload['events'] if event['type'] == 'stream']
+        results = [event['data']['text/plain'] for event in payload['events'] if event['type'] == 'execute_result']
+        self.assertIn('zmq ok\n', texts)
+        self.assertIn('42', results)
+
+    def test_restart_clears_live_kernel_state(self) -> None:
+        path = f'restart-{uuid.uuid4().hex[:8]}.ipynb'
+        self._put_notebook(
+            path,
+            [
+                {
+                    'id': 'restart-cell',
+                    'cell_type': 'code',
+                    'execution_count': None,
+                    'metadata': {},
+                    'outputs': [],
+                    'source': 'baseline = 1',
+                }
+            ],
+        )
+        self._create_session_for_path(path)
+
+        self._run_cli(
+            'execute',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--code',
+            'survivor = 99',
+            '--compact',
+        )
+        self._run_cli('restart', '--port', str(self.port), '--path', path, '--compact')
+        payload = self._run_cli(
+            'execute',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--code',
+            '"survivor" in globals()',
+            '--compact',
+        )
+        results = [event['data']['text/plain'] for event in payload['events'] if event['type'] == 'execute_result']
+        self.assertIn('False', results)
+
+    def test_run_all_executes_cells_in_order_without_persisting_outputs(self) -> None:
+        path = f'run-all-{uuid.uuid4().hex[:8]}.ipynb'
+        self._put_notebook(
+            path,
+            [
+                {
+                    'id': 'cell-one',
+                    'cell_type': 'code',
+                    'execution_count': None,
+                    'metadata': {},
+                    'outputs': [],
+                    'source': 'base = 10',
+                },
+                {
+                    'id': 'cell-two',
+                    'cell_type': 'code',
+                    'execution_count': None,
+                    'metadata': {},
+                    'outputs': [],
+                    'source': 'derived = base + 5',
+                },
+                {
+                    'id': 'cell-three',
+                    'cell_type': 'code',
+                    'execution_count': None,
+                    'metadata': {},
+                    'outputs': [],
+                    'source': 'derived * 2',
+                },
+            ],
+        )
+        self._create_session_for_path(path)
+
+        payload = self._run_cli('run-all', '--port', str(self.port), '--path', path, '--compact')
+        self.assertEqual(payload['status'], 'ok')
+        self.assertEqual(payload['executed_cell_count'], 3)
+        self.assertIsNone(payload['failed_cell'])
+
+        execution = self._run_cli(
+            'execute',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--code',
+            'derived',
+            '--compact',
+        )
+        results = [event['data']['text/plain'] for event in execution['events'] if event['type'] == 'execute_result']
+        self.assertIn('15', results)
+
+        contents = self._contents_with_outputs(path)
+        self.assertEqual(contents['cells'][2]['outputs'], [])
+        self.assertIsNone(contents['cells'][2]['execution_count'])
+
+    def test_restart_run_all_rebuilds_notebook_state(self) -> None:
+        path = f'restart-run-all-{uuid.uuid4().hex[:8]}.ipynb'
+        self._put_notebook(
+            path,
+            [
+                {
+                    'id': 'seed-cell',
+                    'cell_type': 'code',
+                    'execution_count': None,
+                    'metadata': {},
+                    'outputs': [],
+                    'source': 'seed = 1',
+                },
+                {
+                    'id': 'check-cell',
+                    'cell_type': 'code',
+                    'execution_count': None,
+                    'metadata': {},
+                    'outputs': [],
+                    'source': 'seed',
+                },
+            ],
+        )
+        self._create_session_for_path(path)
+
+        self._run_cli(
+            'execute',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--code',
+            'seed = 999',
+            '--compact',
+        )
+        payload = self._run_cli('restart-run-all', '--port', str(self.port), '--path', path, '--compact')
+        self.assertEqual(payload['run_all']['status'], 'ok')
+
+        execution = self._run_cli(
+            'execute',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--code',
+            'seed',
+            '--compact',
+        )
+        results = [event['data']['text/plain'] for event in execution['events'] if event['type'] == 'execute_result']
+        self.assertIn('1', results)
+
+    def test_run_all_returns_nonzero_when_a_cell_fails(self) -> None:
+        path = f'run-all-fail-{uuid.uuid4().hex[:8]}.ipynb'
+        self._put_notebook(
+            path,
+            [
+                {
+                    'id': 'ok-cell',
+                    'cell_type': 'code',
+                    'execution_count': None,
+                    'metadata': {},
+                    'outputs': [],
+                    'source': 'before = 3',
+                },
+                {
+                    'id': 'fail-cell',
+                    'cell_type': 'code',
+                    'execution_count': None,
+                    'metadata': {},
+                    'outputs': [],
+                    'source': 'raise RuntimeError("boom")',
+                },
+            ],
+        )
+        self._create_session_for_path(path)
+
+        payload = self._run_cli_error('run-all', '--port', str(self.port), '--path', path, '--compact')
+        self.assertEqual(payload['status'], 'error')
+        self.assertEqual(payload['failed_cell']['cell_id'], 'fail-cell')
+
+    def test_restart_run_all_returns_nonzero_when_a_cell_fails(self) -> None:
+        path = f'restart-run-all-fail-{uuid.uuid4().hex[:8]}.ipynb'
+        self._put_notebook(
+            path,
+            [
+                {
+                    'id': 'seed-cell',
+                    'cell_type': 'code',
+                    'execution_count': None,
+                    'metadata': {},
+                    'outputs': [],
+                    'source': 'seed = 1',
+                },
+                {
+                    'id': 'fail-cell',
+                    'cell_type': 'code',
+                    'execution_count': None,
+                    'metadata': {},
+                    'outputs': [],
+                    'source': 'raise ValueError("nope")',
+                },
+            ],
+        )
+        self._create_session_for_path(path)
+
+        payload = self._run_cli_error('restart-run-all', '--port', str(self.port), '--path', path, '--compact')
+        self.assertEqual(payload['run_all']['status'], 'error')
+        self.assertEqual(payload['run_all']['failed_cell']['cell_id'], 'fail-cell')
+
+    def test_variables_list_and_preview(self) -> None:
+        path = f'variables-{uuid.uuid4().hex[:8]}.ipynb'
+        self._put_notebook(
+            path,
+            [
+                {
+                    'id': 'vars-cell',
+                    'cell_type': 'code',
+                    'execution_count': None,
+                    'metadata': {},
+                    'outputs': [],
+                    'source': 'placeholder = None',
+                }
+            ],
+        )
+        self._create_session_for_path(path)
+
+        self._run_cli(
+            'execute',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--code',
+            (
+                'demo_numbers = [0, 1, 2, 3]\n'
+                'demo_label = "abc"\n'
+                'class Dangerous:\n'
+                '    def __repr__(self):\n'
+                '        raise RuntimeError("repr should not run")\n'
+                'danger = Dangerous()'
+            ),
+            '--compact',
+        )
+
+        variables = self._run_cli(
+            'variables',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--transport',
+            'zmq',
+            'list',
+            '--compact',
+        )
+        names = {item['name'] for item in variables['variables']}
+        self.assertIn('demo_numbers', names)
+        self.assertIn('demo_label', names)
+        self.assertNotIn('get_ipython', names)
+
+        preview = self._run_cli(
+            'variables',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--transport',
+            'zmq',
+            'preview',
+            '--name',
+            'demo_numbers',
+            '--max-chars',
+            '20',
+            '--compact',
+        )
+        self.assertEqual(preview['variable']['type'], 'list')
+        self.assertEqual(preview['variable']['preview']['kind'], 'list')
+        self.assertEqual(preview['variable']['preview']['length'], 4)
+        self.assertEqual(preview['variable']['preview']['items'], [0, 1, 2, 3])
+
+        preview = self._run_cli(
+            'variables',
+            '--port',
+            str(self.port),
+            '--path',
+            path,
+            '--transport',
+            'zmq',
+            'preview',
+            '--name',
+            'danger',
+            '--max-chars',
+            '20',
+            '--compact',
+        )
+        self.assertEqual(preview['variable']['type'], 'Dangerous')
+        self.assertEqual(preview['variable']['preview'], '<__main__.Dangerous>')
+
+    def test_conflicting_live_target_flags_fail_fast(self) -> None:
+        other_path = f'conflict-{uuid.uuid4().hex[:8]}.ipynb'
+        self._put_notebook(
+            other_path,
+            [
+                {
+                    'id': 'other-cell',
+                    'cell_type': 'code',
+                    'execution_count': None,
+                    'metadata': {},
+                    'outputs': [],
+                    'source': 'other = 1',
+                }
+            ],
+        )
+        other_session = self._create_session_for_path(other_path)
+
+        payload = self._run_cli_error(
+            'execute',
+            '--port',
+            str(self.port),
+            '--path',
+            NOTEBOOK_PATH,
+            '--session-id',
+            str(other_session['id']),
+            '--code',
+            '1 + 1',
+        )
+        self.assertIn('Conflicting live target selectors', payload['error'])
+
+    def test_kernel_id_must_match_a_live_session(self) -> None:
+        payload = self._run_cli_error(
+            'execute',
+            '--port',
+            str(self.port),
+            '--kernel-id',
+            'missing-kernel-id',
+            '--code',
+            '1 + 1',
+        )
+        self.assertIn('No live session matched kernel id', payload['error'])
+
+    def test_variables_enforce_bounded_limits(self) -> None:
+        payload = self._run_cli_error(
+            'variables',
+            '--port',
+            str(self.port),
+            '--path',
+            NOTEBOOK_PATH,
+            'list',
+            '--limit',
+            '-1',
+        )
+        self.assertIn('limit must be at least 1', payload['error'])
+
+        payload = self._run_cli_error(
+            'variables',
+            '--port',
+            str(self.port),
+            '--path',
+            NOTEBOOK_PATH,
+            'preview',
+            '--name',
+            'a',
+            '--max-chars',
+            '5000',
+        )
+        self.assertIn('max-chars must be at most 2000', payload['error'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/video/.gitignore
+++ b/video/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+out

--- a/video/package-lock.json
+++ b/video/package-lock.json
@@ -1,0 +1,3382 @@
+{
+  "name": "hamelnb-video",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hamelnb-video",
+      "version": "0.0.1",
+      "dependencies": {
+        "@remotion/google-fonts": "4.0.434",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
+        "remotion": "4.0.434"
+      },
+      "devDependencies": {
+        "@remotion/cli": "4.0.434",
+        "typescript": "5.9.2"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
+      "integrity": "sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
+      "integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
+      "integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
+      "integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
+      "integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
+      "integrity": "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
+      "integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
+      "integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
+      "integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
+      "integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
+      "integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
+      "integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
+      "integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
+      "integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
+      "integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
+      "integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
+      "integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
+      "integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
+      "integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
+      "integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
+      "integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mediabunny/aac-encoder": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@mediabunny/aac-encoder/-/aac-encoder-1.37.0.tgz",
+      "integrity": "sha512-mYnF1sObnPE+7+QWn9H7c0rbl5Dwu50JejUD/GJefRl8ozYp0sz3tt+zBLCeif5GXBkPhABIX3JVg1eGfqx6tg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      },
+      "peerDependencies": {
+        "mediabunny": "^1.0.0"
+      }
+    },
+    "node_modules/@mediabunny/flac-encoder": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@mediabunny/flac-encoder/-/flac-encoder-1.37.0.tgz",
+      "integrity": "sha512-VwKIL5p1WZE4dSwZ1SVv/bd2ksul8a4run4S1eEbPRysnG87nmCXddO5ajD3b2k2478XWitKnVDXl/kxdIIWBw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      },
+      "peerDependencies": {
+        "mediabunny": "^1.0.0"
+      }
+    },
+    "node_modules/@mediabunny/mp3-encoder": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@mediabunny/mp3-encoder/-/mp3-encoder-1.37.0.tgz",
+      "integrity": "sha512-6tXBO3iHDA55WiMhOoaOmeCCOQ51U38mdXRxYNS9/hUCpR0ScRo+NtWu2YUa/jp2q99JNPrA4yYjahE5xHDxpg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      },
+      "peerDependencies": {
+        "mediabunny": "^1.0.0"
+      }
+    },
+    "node_modules/@module-federation/error-codes": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.22.0.tgz",
+      "integrity": "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/runtime": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.22.0.tgz",
+      "integrity": "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.22.0",
+        "@module-federation/runtime-core": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/runtime-core": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.22.0.tgz",
+      "integrity": "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/runtime-tools": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.22.0.tgz",
+      "integrity": "sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.22.0",
+        "@module-federation/webpack-bundler-runtime": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/sdk": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.22.0.tgz",
+      "integrity": "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/webpack-bundler-runtime": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.22.0.tgz",
+      "integrity": "sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
+      "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.5.0",
+        "@emnapi/runtime": "^1.5.0",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@remotion/bundler": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/bundler/-/bundler-4.0.434.tgz",
+      "integrity": "sha512-S62GkQnMbS/svtNTxZwWvKE7oCSVGaeZllMMig07bFXsf+xLbgfZDBhe4iMqdOyk9+++OVmwgz0qNo+1q2r0FQ==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@remotion/media-parser": "4.0.434",
+        "@remotion/studio": "4.0.434",
+        "@remotion/studio-shared": "4.0.434",
+        "@rspack/core": "1.7.6",
+        "@rspack/plugin-react-refresh": "1.6.1",
+        "css-loader": "5.2.7",
+        "esbuild": "0.25.0",
+        "react-refresh": "0.18.0",
+        "remotion": "4.0.434",
+        "source-map": "0.7.3",
+        "style-loader": "4.0.0",
+        "webpack": "5.105.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/cli": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/cli/-/cli-4.0.434.tgz",
+      "integrity": "sha512-yuZYBQ1mXCJJaQHAf60Y1HupCWGqIM3hV+BYrGwx/TiXqv1GVMU4On5yuJSGVKoOc8ZTZkorOB0gNzB8fzC8qg==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@remotion/bundler": "4.0.434",
+        "@remotion/media-utils": "4.0.434",
+        "@remotion/player": "4.0.434",
+        "@remotion/renderer": "4.0.434",
+        "@remotion/studio": "4.0.434",
+        "@remotion/studio-server": "4.0.434",
+        "@remotion/studio-shared": "4.0.434",
+        "dotenv": "17.3.1",
+        "minimist": "1.2.6",
+        "prompts": "2.4.2",
+        "remotion": "4.0.434"
+      },
+      "bin": {
+        "remotion": "remotion-cli.js",
+        "remotionb": "remotionb-cli.js",
+        "remotiond": "remotiond-cli.js"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/compositor-darwin-arm64": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-arm64/-/compositor-darwin-arm64-4.0.434.tgz",
+      "integrity": "sha512-9nJgIQcUrOYhr9EsbvCMNhC7g/HD/R+cDPsatFaD2FONHHNLKLZQp/wHGyPfcriblvoxy2hRjfqV8Z7nmkaWAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@remotion/compositor-darwin-x64": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-x64/-/compositor-darwin-x64-4.0.434.tgz",
+      "integrity": "sha512-oIlEnStUCdVQbP5DB0GSXCavoWUaSpd+1z1VsSd7x9QfHiv4BsVjit3Say/HejoJB27YxuSzol47qhRDrruPEA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-arm64-gnu": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-gnu/-/compositor-linux-arm64-gnu-4.0.434.tgz",
+      "integrity": "sha512-928YpjfSKcVBIIJl1HI7KYiYYYQpsxdVldzvDjl3eWViqExeErzsS/R0lH/cDSaxtHttFDw+FgKr3RKsX9Yc8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-arm64-musl": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-musl/-/compositor-linux-arm64-musl-4.0.434.tgz",
+      "integrity": "sha512-8xEEhKk0E+dTtHnr/ESIZX1USBc6w/pbsxddzLFtaQLsfyiM+lfpvL/j/gYVdTZbqKe9idOkX14n3GlIu4N9rA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-x64-gnu": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-gnu/-/compositor-linux-x64-gnu-4.0.434.tgz",
+      "integrity": "sha512-zvzLVeSK08j9U0z2FokwQ4DXAdbvL5oUboikR7G5l4e+ziYGx7dukCsTBDBb5Egd8eT+497viaWNSi1dK7hY0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-x64-musl": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-musl/-/compositor-linux-x64-musl-4.0.434.tgz",
+      "integrity": "sha512-Dze2Dsu+1oMmBrTQXWIfL+PwlA7XG2wBoaIE2W6/UAWAdKRb7vRybenDT7vIL9ErVREnVDxwHLF4NwpB2WeMFA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-win32-x64-msvc": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-win32-x64-msvc/-/compositor-win32-x64-msvc-4.0.434.tgz",
+      "integrity": "sha512-3PmLo03LBYf123FvjlUNphbtnTJnvToHMDgBQYdrlQBGbAQpJGLsX7IViQwWSNFGZVzonwliNtC9568Nbts8lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@remotion/google-fonts": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/google-fonts/-/google-fonts-4.0.434.tgz",
+      "integrity": "sha512-8FI5xPQ7kmdyWckMKRfHJuUbxGHaCSXdEgcqhwbWxRIwmGRuAQbyu2+Q6rh7pFzgl3eyXvqqF4SfE4eA3imXoA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "remotion": "4.0.434"
+      }
+    },
+    "node_modules/@remotion/licensing": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/licensing/-/licensing-4.0.434.tgz",
+      "integrity": "sha512-Jp9pHUlQBOX7ZjDuG9OVIEDGU5JiN2eSjvHEDS8zwyIIGUaRwDhZRzvGULEiZpu1IJ6UMDpHqIylJ18Inl1PMg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@remotion/media-parser": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/media-parser/-/media-parser-4.0.434.tgz",
+      "integrity": "sha512-+vuVOTd3v9BR2WQE3N4CUsCCUb4z8U1bvvxKrP6NGL9nqudu6IQpueXHNwxc/RzDTaxJ1aH6xOLzB3Iqc6EnIA==",
+      "dev": true,
+      "license": "Remotion License https://remotion.dev/license"
+    },
+    "node_modules/@remotion/media-utils": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/media-utils/-/media-utils-4.0.434.tgz",
+      "integrity": "sha512-3wBtgZSBNXqwQFqQp6eLwsw3m32zlGhZHsD8bn1TeBJQkHflUXo3WhmGkLoUoZdU8nGutFOoFtckjVq1DEXzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@remotion/media-parser": "4.0.434",
+        "@remotion/webcodecs": "4.0.434",
+        "mediabunny": "1.37.0",
+        "remotion": "4.0.434"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/player": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.434.tgz",
+      "integrity": "sha512-H3SugDjf0QS7lU85A/hej+zUqJLRd0EHfW0jBsu4kerYVXZqi2vswqf7MRqEwQhMGtySVrhI+n9fGBqfcAbRpw==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "remotion": "4.0.434"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/renderer": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/renderer/-/renderer-4.0.434.tgz",
+      "integrity": "sha512-I0MT0A6YHpO420ntQjF0KzERetpYcnsHlMNUWlNFDeAzFuEjrOgUcZ+6NcUV1lX9nOhixLANvfuMpCrdZazdYg==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@remotion/licensing": "4.0.434",
+        "@remotion/streaming": "4.0.434",
+        "execa": "5.1.1",
+        "extract-zip": "2.0.1",
+        "remotion": "4.0.434",
+        "source-map": "^0.8.0-beta.0",
+        "ws": "8.17.1"
+      },
+      "optionalDependencies": {
+        "@remotion/compositor-darwin-arm64": "4.0.434",
+        "@remotion/compositor-darwin-x64": "4.0.434",
+        "@remotion/compositor-linux-arm64-gnu": "4.0.434",
+        "@remotion/compositor-linux-arm64-musl": "4.0.434",
+        "@remotion/compositor-linux-x64-gnu": "4.0.434",
+        "@remotion/compositor-linux-x64-musl": "4.0.434",
+        "@remotion/compositor-win32-x64-msvc": "4.0.434"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/renderer/node_modules/source-map": {
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "deprecated": "The work that was done in this beta branch won't be included in future versions",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "whatwg-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@remotion/streaming": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/streaming/-/streaming-4.0.434.tgz",
+      "integrity": "sha512-Qlb7sSSXs3nkbs/C/62fLIn/ZxUiNdqtnim3AzAMmi9HdC1qcCMAJiQfugnpnKQ57xbS5Okp1HzSPQalpcgXgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@remotion/studio": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/studio/-/studio-4.0.434.tgz",
+      "integrity": "sha512-faNm11hVsjFyjNg9R7TQZcjsDflUfqkWGgbrq5jSubpVJD+eHEVBo1HIZwrDHIlvee8gTyAscR0tFrH27PLShQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@remotion/media-utils": "4.0.434",
+        "@remotion/player": "4.0.434",
+        "@remotion/renderer": "4.0.434",
+        "@remotion/studio-shared": "4.0.434",
+        "@remotion/web-renderer": "4.0.434",
+        "@remotion/zod-types": "4.0.434",
+        "mediabunny": "1.37.0",
+        "memfs": "3.4.3",
+        "open": "^8.4.2",
+        "remotion": "4.0.434",
+        "semver": "7.5.3",
+        "source-map": "0.7.3",
+        "zod": "4.3.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/studio-server": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-server/-/studio-server-4.0.434.tgz",
+      "integrity": "sha512-k1j7he3H6H19t0iiJ6qNRqzJiGqLzpSfFoi7Hb1NVAwFbcrBOYCsRh/sr+ecL5VMAcWZf2s+cgnaL+mZD6sCrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "7.24.1",
+        "@remotion/bundler": "4.0.434",
+        "@remotion/renderer": "4.0.434",
+        "@remotion/studio-shared": "4.0.434",
+        "memfs": "3.4.3",
+        "open": "^8.4.2",
+        "prettier": "3.8.1",
+        "recast": "0.23.11",
+        "remotion": "4.0.434",
+        "semver": "7.5.3",
+        "source-map": "0.7.3"
+      }
+    },
+    "node_modules/@remotion/studio-shared": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-shared/-/studio-shared-4.0.434.tgz",
+      "integrity": "sha512-5HL2ciT8BpGW8izhwOehMBVh2fR+/2X5EjoIUlWrXoDWpSgzSXmT8yI2nkKmBCxbZyYyyW/pQZKkvDj56jcB2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "remotion": "4.0.434"
+      }
+    },
+    "node_modules/@remotion/web-renderer": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/web-renderer/-/web-renderer-4.0.434.tgz",
+      "integrity": "sha512-yYLQ/BbIlHd61pFH0B979UYWUnSMwubXvf1jeyu6w7/44Z2ZbI4h05fzzvIKEr9XZFZSVntBWeFUHuNCf/Tomg==",
+      "dev": true,
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@mediabunny/aac-encoder": "1.37.0",
+        "@mediabunny/flac-encoder": "1.37.0",
+        "@mediabunny/mp3-encoder": "1.37.0",
+        "@remotion/licensing": "4.0.434",
+        "mediabunny": "1.37.0",
+        "remotion": "4.0.434"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@remotion/webcodecs": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/webcodecs/-/webcodecs-4.0.434.tgz",
+      "integrity": "sha512-Eq/3EB9w0L2F4Q2lgTXcc7maoGYn0nkfvoKclVkA4N6gsfgNand+SX/nDe8n8JMOD8NsEKOs5EEd3YWYY3oN5A==",
+      "dev": true,
+      "license": "Remotion License (See https://remotion.dev/docs/webcodecs#license)",
+      "dependencies": {
+        "@remotion/media-parser": "4.0.434"
+      }
+    },
+    "node_modules/@remotion/zod-types": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/@remotion/zod-types/-/zod-types-4.0.434.tgz",
+      "integrity": "sha512-5urhO+1NYCWvddy7cPdqqfHH+VLHP1+5pREO8fqwemIU6jmJR9SFR0vDgMa9wyrQfGyQA7Q0sTMX73KInwszFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "remotion": "4.0.434"
+      },
+      "peerDependencies": {
+        "zod": "4.3.6"
+      }
+    },
+    "node_modules/@rspack/binding": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.7.6.tgz",
+      "integrity": "sha512-/NrEcfo8Gx22hLGysanrV6gHMuqZSxToSci/3M4kzEQtF5cPjfOv5pqeLK/+B6cr56ul/OmE96cCdWcXeVnFjQ==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "@rspack/binding-darwin-arm64": "1.7.6",
+        "@rspack/binding-darwin-x64": "1.7.6",
+        "@rspack/binding-linux-arm64-gnu": "1.7.6",
+        "@rspack/binding-linux-arm64-musl": "1.7.6",
+        "@rspack/binding-linux-x64-gnu": "1.7.6",
+        "@rspack/binding-linux-x64-musl": "1.7.6",
+        "@rspack/binding-wasm32-wasi": "1.7.6",
+        "@rspack/binding-win32-arm64-msvc": "1.7.6",
+        "@rspack/binding-win32-ia32-msvc": "1.7.6",
+        "@rspack/binding-win32-x64-msvc": "1.7.6"
+      }
+    },
+    "node_modules/@rspack/binding-darwin-arm64": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.7.6.tgz",
+      "integrity": "sha512-NZ9AWtB1COLUX1tA9HQQvWpTy07NSFfKBU8A6ylWd5KH8AePZztpNgLLAVPTuNO4CZXYpwcoclf8jG/luJcQdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rspack/binding-darwin-x64": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.7.6.tgz",
+      "integrity": "sha512-J2g6xk8ZS7uc024dNTGTHxoFzFovAZIRixUG7PiciLKTMP78svbSSWrmW6N8oAsAkzYfJWwQpVgWfFNRHvYxSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-arm64-gnu": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.7.6.tgz",
+      "integrity": "sha512-eQfcsaxhFrv5FmtaA7+O1F9/2yFDNIoPZzV/ZvqvFz5bBXVc4FAm/1fVpBg8Po/kX1h0chBc7Xkpry3cabFW8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-arm64-musl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.7.6.tgz",
+      "integrity": "sha512-DfQXKiyPIl7i1yECHy4eAkSmlUzzsSAbOjgMuKn7pudsWf483jg0UUYutNgXSlBjc/QSUp7906Cg8oty9OfwPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-x64-gnu": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.7.6.tgz",
+      "integrity": "sha512-NdA+2X3lk2GGrMMnTGyYTzM3pn+zNjaqXqlgKmFBXvjfZqzSsKq3pdD1KHZCd5QHN+Fwvoszj0JFsquEVhE1og==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-x64-musl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.7.6.tgz",
+      "integrity": "sha512-rEy6MHKob02t/77YNgr6dREyJ0e0tv1X6Xsg8Z5E7rPXead06zefUbfazj4RELYySWnM38ovZyJAkPx/gOn3VA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-wasm32-wasi": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.7.6.tgz",
+      "integrity": "sha512-YupOrz0daSG+YBbCIgpDgzfMM38YpChv+afZpaxx5Ml7xPeAZIIdgWmLHnQ2rts73N2M1NspAiBwV00Xx0N4Vg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "1.0.7"
+      }
+    },
+    "node_modules/@rspack/binding-win32-arm64-msvc": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.7.6.tgz",
+      "integrity": "sha512-INj7aVXjBvlZ84kEhSK4kJ484ub0i+BzgnjDWOWM1K+eFYDZjLdAsQSS3fGGXwVc3qKbPIssFfnftATDMTEJHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/binding-win32-ia32-msvc": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.7.6.tgz",
+      "integrity": "sha512-lXGvC+z67UMcw58In12h8zCa9IyYRmuptUBMItQJzu+M278aMuD1nETyGLL7e4+OZ2lvrnnBIcjXN1hfw2yRzw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/binding-win32-x64-msvc": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.7.6.tgz",
+      "integrity": "sha512-zeUxEc0ZaPpmaYlCeWcjSJUPuRRySiSHN23oJ2Xyw0jsQ01Qm4OScPdr0RhEOFuK/UE+ANyRtDo4zJsY52Hadw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/core": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.7.6.tgz",
+      "integrity": "sha512-Iax6UhrfZqJajA778c1d5DBFbSIqPOSrI34kpNIiNpWd8Jq7mFIa+Z60SQb5ZQDZuUxcCZikjz5BxinFjTkg7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime-tools": "0.22.0",
+        "@rspack/binding": "1.7.6",
+        "@rspack/lite-tapable": "1.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.1"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rspack/lite-tapable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.1.0.tgz",
+      "integrity": "sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rspack/plugin-react-refresh": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@rspack/plugin-react-refresh/-/plugin-react-refresh-1.6.1.tgz",
+      "integrity": "sha512-eqqW5645VG3CzGzFgNg5HqNdHVXY+567PGjtDhhrM8t67caxmsSzRmT5qfoEIfBcGgFkH9vEg7kzXwmCYQdQDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "error-stack-parser": "^2.1.4",
+        "html-entities": "^2.6.0"
+      },
+      "peerDependencies": {
+        "react-refresh": ">=0.10.0 <1.0.0",
+        "webpack-hot-middleware": "2.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-hot-middleware": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/dom-mediacapture-transform": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.11.tgz",
+      "integrity": "sha512-Y2p+nGf1bF2XMttBnsVPHUWzRRZzqUoJAKmiP10b5umnO6DDrWI0BrGDJy1pOHoOULVmGSfFNkQrAlC5dcj6nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "*"
+      }
+    },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz",
+      "integrity": "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.3.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
+      "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001777",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
+      "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-loader": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.7.tgz",
+      "integrity": "sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.1.0",
+        "loader-utils": "^2.0.0",
+        "postcss": "^8.2.15",
+        "postcss-modules-extract-imports": "^3.0.0",
+        "postcss-modules-local-by-default": "^4.0.0",
+        "postcss-modules-scope": "^3.0.0",
+        "postcss-modules-values": "^4.0.0",
+        "postcss-value-parser": "^4.1.0",
+        "schema-utils": "^3.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.27.0 || ^5.0.0"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.307",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
+      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
+      "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.0",
+        "@esbuild/android-arm": "0.25.0",
+        "@esbuild/android-arm64": "0.25.0",
+        "@esbuild/android-x64": "0.25.0",
+        "@esbuild/darwin-arm64": "0.25.0",
+        "@esbuild/darwin-x64": "0.25.0",
+        "@esbuild/freebsd-arm64": "0.25.0",
+        "@esbuild/freebsd-x64": "0.25.0",
+        "@esbuild/linux-arm": "0.25.0",
+        "@esbuild/linux-arm64": "0.25.0",
+        "@esbuild/linux-ia32": "0.25.0",
+        "@esbuild/linux-loong64": "0.25.0",
+        "@esbuild/linux-mips64el": "0.25.0",
+        "@esbuild/linux-ppc64": "0.25.0",
+        "@esbuild/linux-riscv64": "0.25.0",
+        "@esbuild/linux-s390x": "0.25.0",
+        "@esbuild/linux-x64": "0.25.0",
+        "@esbuild/netbsd-arm64": "0.25.0",
+        "@esbuild/netbsd-x64": "0.25.0",
+        "@esbuild/openbsd-arm64": "0.25.0",
+        "@esbuild/openbsd-x64": "0.25.0",
+        "@esbuild/sunos-x64": "0.25.0",
+        "@esbuild/win32-arm64": "0.25.0",
+        "@esbuild/win32-ia32": "0.25.0",
+        "@esbuild/win32-x64": "0.25.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fs-monkey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
+      "integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loader-runner": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/loader-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mediabunny": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.37.0.tgz",
+      "integrity": "sha512-eV7M9IJ29pr/8RNL1sYtIxNbdMfDMN1hMwMaOFfNLhwuKKGSC+eKwiJFpdVjEJ3zrMA4LGerF4Hps0SENFSAlg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@types/dom-mediacapture-transform": "^0.1.11",
+        "@types/dom-webcodecs": "0.1.13"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      }
+    },
+    "node_modules/memfs": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.3.tgz",
+      "integrity": "sha512-eivjfi7Ahr6eQTn44nvTnR60e4a1Fs1Via2kCR5lHo/kyNoiMWaXCNJ/GpSd0ilXas2JSOl9B5FTIhflXu0hlg==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "fs-monkey": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-modules-extract-imports": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
+      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-local-by-default": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
+      "integrity": "sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^7.0.0",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-scope": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
+      "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "icss-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recast": {
+      "version": "0.23.11",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
+      "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/recast/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/remotion": {
+      "version": "4.0.434",
+      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.434.tgz",
+      "integrity": "sha512-r5SRjrB9lFeZPkNGTcFG0qJJOhV7m/W/xandMvReCZyvV8D3ScmfpJWqRoq/zGzBt6t2F6TW/3sUQ0QTU110ZQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/style-loader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
+      "integrity": "sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.27.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
+      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
+      "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchpack": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/webpack": {
+      "version": "5.105.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
+      "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.15.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.19.0",
+        "es-module-lexer": "^2.0.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.3.1",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.16",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/webpack/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/webpack/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/webpack/node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/video/package.json
+++ b/video/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "hamelnb-video",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "render": "remotion render src/index.ts SkillShowcase out/jupyter-live-kernel-demo.mp4",
+    "render:still": "remotion still src/index.ts SkillShowcase out/poster.png --frame 210",
+    "studio": "remotion studio src/index.ts",
+    "compositions": "remotion compositions src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@remotion/google-fonts": "4.0.434",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "remotion": "4.0.434"
+  },
+  "devDependencies": {
+    "@remotion/cli": "4.0.434",
+    "typescript": "5.9.2"
+  }
+}

--- a/video/src/Root.tsx
+++ b/video/src/Root.tsx
@@ -1,0 +1,15 @@
+import {Composition} from 'remotion';
+import {SkillShowcase} from './SkillShowcase';
+
+export const RemotionRoot = () => {
+  return (
+    <Composition
+      id="SkillShowcase"
+      component={SkillShowcase}
+      durationInFrames={600}
+      fps={30}
+      width={1920}
+      height={1080}
+    />
+  );
+};

--- a/video/src/SkillShowcase.tsx
+++ b/video/src/SkillShowcase.tsx
@@ -1,0 +1,1079 @@
+import {loadFont as loadDisplayFont} from '@remotion/google-fonts/HankenGrotesk';
+import {loadFont as loadMonoFont} from '@remotion/google-fonts/MartianMono';
+import type {CSSProperties, ReactNode} from 'react';
+import {
+  AbsoluteFill,
+  Easing,
+  interpolate,
+  spring,
+  useCurrentFrame,
+  useVideoConfig,
+} from 'remotion';
+
+const {fontFamily: displayFont} = loadDisplayFont('normal', {
+  weights: ['500', '700', '800'],
+  subsets: ['latin'],
+});
+const {fontFamily: monoFont} = loadMonoFont('normal', {
+  weights: ['400', '700'],
+  subsets: ['latin'],
+});
+
+type TerminalLineKind = 'command' | 'kernel' | 'diff' | 'note';
+
+type TerminalLine = {
+  text: string;
+  kind: TerminalLineKind;
+  start: number;
+  speed?: number;
+};
+
+const COLORS = {
+  ink: '#081119',
+  panel: '#0d1720',
+  panelBorder: 'rgba(156, 188, 207, 0.16)',
+  panelGlow: 'rgba(49, 191, 166, 0.18)',
+  paper: '#f6efe5',
+  paperEdge: '#e4d3bf',
+  orange: '#ff9651',
+  amber: '#ffd36a',
+  teal: '#43d7c8',
+  cyan: '#7ed8ff',
+  green: '#87f4a0',
+  red: '#ff7f77',
+  navy: '#112330',
+  steel: '#7790a0',
+  softText: '#c2d0da',
+  mutedDark: '#203545',
+};
+
+const terminalLines: TerminalLine[] = [
+  {text: '$ jupyter-live-kernel exec demo.ipynb 2', kind: 'command', start: 72, speed: 2.8},
+  {text: '[kernel] matched notebook session', kind: 'kernel', start: 110, speed: 3.8},
+  {text: '[kernel] cell 2 ok in 84 ms', kind: 'kernel', start: 128, speed: 3.8},
+  {text: '$ jupyter-live-kernel exec demo.ipynb 3', kind: 'command', start: 192, speed: 2.8},
+  {text: '[kernel] reused dataframe state', kind: 'kernel', start: 228, speed: 3.6},
+  {text: '[kernel] chart written to cell 3', kind: 'kernel', start: 250, speed: 3.7},
+  {text: '$ jupyter-live-kernel edit demo.ipynb 3', kind: 'command', start: 376, speed: 2.8},
+  {text: '+ daily["rolling"] = daily.tokens.ewm(span=3).mean()', kind: 'diff', start: 410, speed: 3.1},
+  {text: '[agent] notebook saved through Contents API', kind: 'note', start: 450, speed: 4.2},
+  {text: '$ jupyter-live-kernel exec demo.ipynb 3', kind: 'command', start: 492, speed: 2.8},
+  {text: '[kernel] updated chart with rolling mean', kind: 'kernel', start: 534, speed: 3.8},
+];
+
+const previewRows = [
+  {day: 'Tue', step: 'load', tokens: 118, sec: '0.7'},
+  {day: 'Wed', step: 'rank', tokens: 154, sec: '0.9'},
+];
+
+const barValues = [118, 154, 165, 218, 236, 264];
+const rollingValues = [118, 136, 150, 184, 210, 237];
+const dayLabels = ['Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+const clamp = (value: number) => Math.max(0, Math.min(1, value));
+
+const easeProgress = (frame: number, start: number, end: number) =>
+  interpolate(frame, [start, end], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+    easing: Easing.bezier(0.22, 1, 0.36, 1),
+  });
+
+const mix = (from: number, to: number, progress: number) => from + (to - from) * progress;
+
+const lineColor = (kind: TerminalLineKind) => {
+  switch (kind) {
+    case 'command':
+      return COLORS.amber;
+    case 'kernel':
+      return COLORS.cyan;
+    case 'diff':
+      return COLORS.green;
+    case 'note':
+      return COLORS.softText;
+    default:
+      return COLORS.softText;
+  }
+};
+
+const visibleText = (line: TerminalLine, frame: number) => {
+  const progress = Math.max(0, frame - line.start);
+  const chars = Math.floor(progress * (line.speed ?? 3.4));
+  return line.text.slice(0, chars);
+};
+
+const isLineTyping = (line: TerminalLine, frame: number) => {
+  const duration = Math.ceil(line.text.length / (line.speed ?? 3.4));
+  return frame >= line.start && frame <= line.start + duration + 4;
+};
+
+const isBusy = (frame: number) => {
+  const inCell2 = frame >= 72 && frame < 138;
+  const inCell3 = frame >= 192 && frame < 266;
+  const inRerun = frame >= 492 && frame < 570;
+  return inCell2 || inCell3 || inRerun;
+};
+
+const Badge = ({label, accent}: {label: string; accent: string}) => (
+  <div
+    style={{
+      padding: '14px 22px',
+      borderRadius: 999,
+      border: `1px solid ${accent}55`,
+      background: `${accent}18`,
+      color: accent,
+      fontFamily: displayFont,
+      fontSize: 24,
+      fontWeight: 700,
+      letterSpacing: '0.06em',
+      textTransform: 'uppercase',
+    }}
+  >
+    {label}
+  </div>
+);
+
+const SectionLabel = ({label, accent}: {label: string; accent: string}) => (
+  <div
+    style={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: 12,
+      color: accent,
+      fontFamily: displayFont,
+      fontSize: 24,
+      fontWeight: 700,
+      letterSpacing: '0.08em',
+      textTransform: 'uppercase',
+    }}
+  >
+    <div
+      style={{
+        width: 14,
+        height: 14,
+        borderRadius: 999,
+        background: accent,
+        boxShadow: `0 0 20px ${accent}99`,
+      }}
+    />
+    {label}
+  </div>
+);
+
+const PanelShell = ({children, style}: {children: ReactNode; style: CSSProperties}) => (
+  <div
+    style={{
+      borderRadius: 34,
+      overflow: 'hidden',
+      boxShadow: '0 26px 90px rgba(0, 0, 0, 0.34)',
+      ...style,
+    }}
+  >
+    {children}
+  </div>
+);
+
+const HeaderBar = ({frame}: {frame: number}) => {
+  const titleProgress = easeProgress(frame, 0, 26);
+  const badgeShift = easeProgress(frame, 14, 44);
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: 68,
+        top: 48,
+        right: 68,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'flex-start',
+        transform: `translateY(${mix(24, 0, titleProgress)}px)`,
+        opacity: titleProgress,
+      }}
+    >
+      <div style={{maxWidth: 980}}>
+        <SectionLabel label="Coding Agent Demo" accent={COLORS.orange} />
+        <div
+          style={{
+            marginTop: 20,
+            color: '#f5f7fb',
+            fontFamily: displayFont,
+            fontSize: 68,
+            fontWeight: 800,
+            lineHeight: 0.96,
+            letterSpacing: '-0.05em',
+          }}
+        >
+          Agent drives a live notebook kernel
+        </div>
+        <div
+          style={{
+            marginTop: 18,
+            color: '#bed0dd',
+            fontFamily: displayFont,
+            fontSize: 22,
+            fontWeight: 500,
+            lineHeight: 1.16,
+            maxWidth: 720,
+          }}
+        >
+          Execute notebook cells incrementally, patch notebook code through the Contents API, and keep the kernel warm.
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          gap: 16,
+          transform: `translateY(${mix(-18, 0, badgeShift)}px)`,
+          opacity: badgeShift,
+        }}
+      >
+        <Badge label="Warm Kernel" accent={COLORS.teal} />
+        <Badge label="Cell Patch" accent={COLORS.amber} />
+        <Badge label="JupyterLab" accent={COLORS.cyan} />
+      </div>
+    </div>
+  );
+};
+
+const TerminalPane = ({frame}: {frame: number}) => {
+  const {fps} = useVideoConfig();
+  const intro = spring({
+    fps,
+    frame: frame - 10,
+    config: {damping: 18, stiffness: 110, mass: 0.85},
+  });
+  const activeIndex = terminalLines.reduce((current, line, index) => {
+    return frame >= line.start ? index : current;
+  }, 0);
+
+  return (
+    <PanelShell
+      style={{
+        flex: 0.93,
+        background: `linear-gradient(180deg, ${COLORS.panel} 0%, #081018 100%)`,
+        border: `1px solid ${COLORS.panelBorder}`,
+        transform: `translateY(${mix(42, 0, intro)}px) scale(${mix(0.96, 1, intro)})`,
+        boxShadow: `0 30px 90px rgba(0, 0, 0, 0.4), 0 0 120px ${COLORS.panelGlow}`,
+      }}
+    >
+      <div
+        style={{
+          height: 84,
+          borderBottom: `1px solid ${COLORS.panelBorder}`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '0 28px',
+          background: 'rgba(255, 255, 255, 0.02)',
+        }}
+      >
+        <div style={{display: 'flex', gap: 12}}>
+          {['#ff6a5a', '#ffc857', '#35d07f'].map((color) => (
+            <div
+              key={color}
+              style={{
+                width: 14,
+                height: 14,
+                borderRadius: 999,
+                background: color,
+                boxShadow: `0 0 16px ${color}66`,
+              }}
+            />
+          ))}
+        </div>
+
+        <div
+          style={{
+            color: '#e8eff5',
+            fontFamily: displayFont,
+            fontSize: 30,
+            fontWeight: 700,
+            letterSpacing: '-0.03em',
+          }}
+        >
+          codex session
+        </div>
+
+        <div
+          style={{
+            padding: '10px 16px',
+            borderRadius: 999,
+            background: isBusy(frame) ? `${COLORS.teal}18` : 'rgba(255, 255, 255, 0.05)',
+            border: `1px solid ${isBusy(frame) ? `${COLORS.teal}55` : COLORS.panelBorder}`,
+            color: isBusy(frame) ? COLORS.teal : COLORS.softText,
+            fontFamily: displayFont,
+            fontSize: 22,
+            fontWeight: 700,
+            textTransform: 'uppercase',
+            letterSpacing: '0.08em',
+          }}
+        >
+          {isBusy(frame) ? 'Running' : 'Idle'}
+        </div>
+      </div>
+
+      <div style={{padding: '28px 32px 24px 32px'}}>
+        <div
+          style={{
+            color: '#6e8697',
+            fontFamily: monoFont,
+            fontSize: 20,
+            marginBottom: 18,
+          }}
+        >
+          /Users/hamel/git/hamelnb
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 10,
+          }}
+        >
+          {terminalLines.map((line, index) => {
+            if (frame < line.start - 6) {
+              return null;
+            }
+
+            const shown = visibleText(line, frame);
+            const typing = isLineTyping(line, frame);
+            const active = index === activeIndex && frame >= line.start;
+            const cursorVisible = typing && Math.floor(frame / 8) % 2 === 0;
+
+            return (
+              <div
+                  key={`${line.start}-${index}`}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  minHeight: 38,
+                  padding: '6px 12px',
+                  marginLeft: line.kind === 'diff' ? 18 : 0,
+                  borderRadius: 14,
+                  background: active ? 'rgba(255, 255, 255, 0.055)' : 'transparent',
+                  border: active ? `1px solid ${COLORS.panelBorder}` : '1px solid transparent',
+                  transform: `translateX(${Math.max(0, line.start - frame) * -1.2}px)`,
+                  opacity: clamp((frame - line.start + 12) / 14),
+                }}
+              >
+                <div
+                  style={{
+                    width: 14,
+                    height: 14,
+                    borderRadius: 999,
+                    marginRight: 14,
+                    background: lineColor(line.kind),
+                    boxShadow: `0 0 14px ${lineColor(line.kind)}55`,
+                    opacity: active ? 1 : 0.45,
+                  }}
+                />
+                <div
+                  style={{
+                    fontFamily: monoFont,
+                    fontSize: 22,
+                    color: lineColor(line.kind),
+                    lineHeight: 1.35,
+                    whiteSpace: 'pre',
+                  }}
+                >
+                  {shown}
+                  {cursorVisible ? '_' : ''}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div
+          style={{
+            marginTop: 28,
+            padding: '22px 24px',
+            borderRadius: 22,
+            background: 'rgba(255, 255, 255, 0.035)',
+            border: `1px solid ${COLORS.panelBorder}`,
+            display: 'grid',
+            gridTemplateColumns: 'repeat(3, 1fr)',
+            gap: 16,
+          }}
+        >
+          {[
+            {label: 'Cells targeted', value: '2 -> 3 -> 3'},
+            {label: 'Kernel restarts', value: '0'},
+            {label: 'Notebook writes', value: '1 save'},
+          ].map((item) => (
+            <div key={item.label}>
+              <div
+                style={{
+                  color: '#7e93a2',
+                  fontFamily: displayFont,
+                  fontSize: 20,
+                  fontWeight: 600,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.08em',
+                }}
+              >
+                {item.label}
+              </div>
+              <div
+                style={{
+                  marginTop: 10,
+                  color: '#f7fbff',
+                  fontFamily: displayFont,
+                  fontSize: 34,
+                  fontWeight: 700,
+                  letterSpacing: '-0.03em',
+                }}
+              >
+                {item.value}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </PanelShell>
+  );
+};
+
+const NotebookHeader = ({frame}: {frame: number}) => {
+  const busy = isBusy(frame);
+  return (
+    <div
+      style={{
+        height: 72,
+        borderBottom: `1px solid ${COLORS.paperEdge}`,
+        background: '#f7f1e7',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '0 22px 0 18px',
+      }}
+    >
+      <div style={{display: 'flex', alignItems: 'center', gap: 18}}>
+        <div
+          style={{
+            width: 24,
+            height: 24,
+            borderRadius: 7,
+            background: COLORS.orange,
+            boxShadow: `0 0 22px ${COLORS.orange}66`,
+          }}
+        />
+        <div
+          style={{
+            padding: '13px 18px',
+            borderRadius: 18,
+            background: '#fff9f1',
+            border: `1px solid ${COLORS.paperEdge}`,
+            color: COLORS.navy,
+            fontFamily: displayFont,
+            fontSize: 24,
+            fontWeight: 700,
+          }}
+        >
+          demo.ipynb
+        </div>
+      </div>
+
+      <div style={{display: 'flex', alignItems: 'center', gap: 14}}>
+        <div
+          style={{
+            color: COLORS.mutedDark,
+            fontFamily: displayFont,
+            fontSize: 20,
+            fontWeight: 700,
+          }}
+        >
+          Python 3 (ipykernel)
+        </div>
+        <div
+          style={{
+            padding: '8px 14px',
+            borderRadius: 999,
+            background: busy ? `${COLORS.orange}18` : '#eef6f0',
+            border: `1px solid ${busy ? `${COLORS.orange}55` : '#bfdcc7'}`,
+            color: busy ? COLORS.orange : '#257a42',
+            fontFamily: displayFont,
+            fontSize: 18,
+            fontWeight: 700,
+            letterSpacing: '0.06em',
+            textTransform: 'uppercase',
+          }}
+        >
+          {busy ? 'Busy' : 'Idle'}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const NotebookCell = ({
+  cellLabel,
+  frame,
+  runWindow,
+  editWindow,
+  codeLines,
+  insertedLine,
+  output,
+}: {
+  cellLabel: string;
+  frame: number;
+  runWindow: [number, number];
+  editWindow?: [number, number];
+  codeLines: string[];
+  insertedLine?: string;
+  output: ReactNode;
+}) => {
+  const running = frame >= runWindow[0] && frame < runWindow[1];
+  const done = frame >= runWindow[1];
+  const editProgress = editWindow ? easeProgress(frame, editWindow[0], editWindow[1]) : 0;
+  const showInserted = insertedLine && frame >= (editWindow?.[0] ?? Number.MAX_SAFE_INTEGER) - 4;
+
+  return (
+    <div
+      style={{
+        borderRadius: 24,
+        overflow: 'hidden',
+        border: `1px solid ${running ? `${COLORS.orange}66` : done ? '#c8d9c6' : COLORS.paperEdge}`,
+        boxShadow: running
+          ? `0 0 0 3px ${COLORS.orange}18`
+          : done
+            ? '0 16px 36px rgba(17, 35, 48, 0.08)'
+            : '0 12px 30px rgba(17, 35, 48, 0.05)',
+        background: '#fffdf9',
+      }}
+    >
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '100px 1fr',
+          background: '#fffaf4',
+        }}
+      >
+        <div
+          style={{
+            padding: '18px 16px',
+            borderRight: `1px solid ${COLORS.paperEdge}`,
+            color: running ? COLORS.orange : '#6d7f89',
+            fontFamily: monoFont,
+            fontSize: 20,
+            fontWeight: 700,
+          }}
+        >
+          In [{cellLabel}]:
+        </div>
+
+        <div style={{padding: '18px 22px 18px 24px'}}>
+          <div style={{display: 'flex', flexDirection: 'column', gap: 10}}>
+            {codeLines.map((line) => (
+              <div
+                key={line}
+                style={{
+                  fontFamily: monoFont,
+                  fontSize: 20,
+                  lineHeight: 1.3,
+                  color: COLORS.navy,
+                  whiteSpace: 'pre',
+                }}
+              >
+                {line}
+              </div>
+            ))}
+
+            {showInserted ? (
+              <div
+                style={{
+                  fontFamily: monoFont,
+                  fontSize: 20,
+                  lineHeight: 1.3,
+                  color: COLORS.navy,
+                  whiteSpace: 'pre',
+                  background: `linear-gradient(90deg, ${COLORS.amber}32 0%, rgba(255, 211, 106, 0.08) 100%)`,
+                  borderRadius: 12,
+                  padding: '7px 10px',
+                  transform: `translateY(${mix(12, 0, editProgress)}px)`,
+                  opacity: insertedLine ? clamp(editProgress + 0.08) : 0,
+                }}
+              >
+                {insertedLine?.slice(0, Math.max(1, Math.floor(insertedLine.length * Math.max(editProgress, 0.18))))}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      <div
+        style={{
+          borderTop: `1px solid ${COLORS.paperEdge}`,
+          display: 'grid',
+          gridTemplateColumns: '100px 1fr',
+          background: '#ffffff',
+        }}
+      >
+        <div
+          style={{
+            padding: '18px 16px',
+            borderRight: `1px solid ${COLORS.paperEdge}`,
+            color: done ? '#2d7a42' : '#9cb0ba',
+            fontFamily: monoFont,
+            fontSize: 20,
+            fontWeight: 700,
+          }}
+        >
+          Out[{cellLabel}]:
+        </div>
+        <div style={{padding: '18px 22px 18px 24px'}}>{output}</div>
+      </div>
+    </div>
+  );
+};
+
+const TableOutput = ({frame}: {frame: number}) => {
+  const reveal = easeProgress(frame, 112, 148);
+  return (
+    <div
+      style={{
+        opacity: reveal,
+        transform: `translateY(${mix(14, 0, reveal)}px)`,
+      }}
+    >
+      <div
+        style={{
+          color: '#4a6271',
+          fontFamily: displayFont,
+          fontSize: 20,
+          fontWeight: 700,
+          marginBottom: 10,
+        }}
+      >
+        842 rows loaded into the active kernel
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '64px 1fr 96px 64px',
+          gap: 10,
+          alignItems: 'center',
+        }}
+      >
+        {['day', 'step', 'tokens', 'sec'].map((label) => (
+          <div
+            key={label}
+            style={{
+              color: '#5b7080',
+              fontFamily: displayFont,
+              fontSize: 17,
+              fontWeight: 800,
+              textTransform: 'uppercase',
+              letterSpacing: '0.06em',
+            }}
+          >
+            {label}
+          </div>
+        ))}
+        {previewRows.map((row, index) => (
+          <div
+            key={row.day}
+            style={{
+              display: 'contents',
+            }}
+          >
+            <div
+              style={{fontFamily: monoFont, fontSize: 18, color: COLORS.navy}}
+            >
+              {row.day}
+            </div>
+            <div
+              style={{fontFamily: monoFont, fontSize: 18, color: COLORS.navy}}
+            >
+              {row.step}
+            </div>
+            <div
+              style={{fontFamily: monoFont, fontSize: 18, color: COLORS.navy}}
+            >
+              {Math.round(mix(0, row.tokens, clamp(reveal - index * 0.08)))}
+            </div>
+            <div
+              style={{fontFamily: monoFont, fontSize: 18, color: COLORS.navy}}
+            >
+              {row.sec}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const TrendOutput = ({frame}: {frame: number}) => {
+  const {fps} = useVideoConfig();
+  const barsIn = easeProgress(frame, 252, 312);
+  const rerunIn = easeProgress(frame, 522, 570);
+  const width = 690;
+  const height = 150;
+  const max = 280;
+  const columnWidth = 74;
+  const gap = 22;
+  const baseline = 118;
+  const points = rollingValues.map((value, index) => {
+    const x = 44 + index * (columnWidth + gap) + columnWidth / 2;
+    const y = baseline - (value / max) * 78;
+    return `${x},${y}`;
+  });
+
+  return (
+    <div
+      style={{
+        opacity: Math.max(barsIn, 0.06),
+        transform: `translateY(${mix(18, 0, barsIn)}px)`,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: 12,
+        }}
+      >
+        <div
+          style={{
+            color: '#4a6271',
+            fontFamily: displayFont,
+            fontSize: 18,
+            fontWeight: 700,
+          }}
+        >
+          Daily token totals from the warm kernel session
+        </div>
+        <div style={{display: 'flex', gap: 18}}>
+          <LegendSwatch label="tokens" color={COLORS.cyan} />
+          <LegendSwatch label="rolling" color={COLORS.orange} active={rerunIn > 0.08} />
+        </div>
+      </div>
+
+      <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
+        <line x1="22" y1={baseline + 0.5} x2={width - 20} y2={baseline + 0.5} stroke="#d5c7b7" strokeWidth="2" />
+        <line x1="22" y1="26" x2="22" y2={baseline + 4} stroke="#d5c7b7" strokeWidth="2" />
+
+        {barValues.map((value, index) => {
+          const delay = index * 6;
+          const growth = spring({
+            fps,
+            frame: frame - 252 - delay,
+            config: {damping: 20, stiffness: 120, mass: 0.9},
+          });
+          const reveal = clamp(growth * barsIn);
+          const heightValue = value / max * 78 * reveal;
+          const x = 44 + index * (columnWidth + gap);
+          const y = baseline - heightValue;
+          const labelValue = Math.round(mix(0, value, reveal));
+          return (
+            <g key={dayLabels[index]}>
+              <rect
+                x={x}
+                y={y}
+                rx="16"
+                width={columnWidth}
+                height={heightValue}
+                fill="url(#tokenGradient)"
+              />
+              <text
+                x={x + columnWidth / 2}
+                y={y - 12}
+                textAnchor="middle"
+                fontFamily={displayFont}
+                fontWeight="700"
+                fontSize="16"
+                fill={COLORS.navy}
+              >
+                {labelValue}
+              </text>
+              <text
+                x={x + columnWidth / 2}
+                y={baseline + 22}
+                textAnchor="middle"
+                fontFamily={displayFont}
+                fontWeight="700"
+                fontSize="16"
+                fill="#526877"
+              >
+                {dayLabels[index]}
+              </text>
+            </g>
+          );
+        })}
+
+        <polyline
+          points={points.join(' ')}
+          fill="none"
+          stroke={COLORS.orange}
+          strokeWidth="7"
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          pathLength={1}
+          strokeDasharray={1}
+          strokeDashoffset={1 - rerunIn}
+          opacity={rerunIn}
+        />
+
+        {rollingValues.map((value, index) => {
+          const x = 44 + index * (columnWidth + gap) + columnWidth / 2;
+          const y = baseline - (value / max) * 78;
+          return (
+            <circle
+              key={`dot-${dayLabels[index]}`}
+              cx={x}
+              cy={y}
+              r={mix(0, 5, rerunIn)}
+              fill={COLORS.orange}
+              opacity={rerunIn}
+            />
+          );
+        })}
+
+        <defs>
+          <linearGradient id="tokenGradient" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor="#7ed8ff" />
+            <stop offset="100%" stopColor="#2ba6d8" />
+          </linearGradient>
+        </defs>
+      </svg>
+    </div>
+  );
+};
+
+const LegendSwatch = ({
+  label,
+  color,
+  active = true,
+}: {
+  label: string;
+  color: string;
+  active?: boolean;
+}) => (
+  <div
+    style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 8,
+      opacity: active ? 1 : 0.35,
+    }}
+  >
+    <div
+      style={{
+        width: 16,
+        height: 16,
+        borderRadius: 999,
+        background: color,
+      }}
+    />
+    <div
+      style={{
+        color: '#516878',
+        fontFamily: displayFont,
+        fontSize: 16,
+        fontWeight: 700,
+        textTransform: 'uppercase',
+        letterSpacing: '0.06em',
+      }}
+    >
+      {label}
+    </div>
+  </div>
+);
+
+const NotebookPane = ({frame}: {frame: number}) => {
+  const {fps} = useVideoConfig();
+  const intro = spring({
+    fps,
+    frame: frame - 18,
+    config: {damping: 18, stiffness: 105, mass: 0.9},
+  });
+
+  return (
+    <PanelShell
+      style={{
+        flex: 1.18,
+        background: `linear-gradient(180deg, ${COLORS.paper} 0%, #f9f4ed 100%)`,
+        border: `1px solid ${COLORS.paperEdge}`,
+        transform: `translateY(${mix(58, 0, intro)}px) scale(${mix(0.95, 1, intro)})`,
+      }}
+    >
+      <NotebookHeader frame={frame} />
+      <div
+        style={{
+          padding: '18px 20px 20px 20px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 16,
+        }}
+      >
+        <NotebookCell
+          cellLabel="2"
+          frame={frame}
+          runWindow={[72, 138]}
+          codeLines={['logs = load_agent_runs()', 'logs.tail(4)']}
+          output={<TableOutput frame={frame} />}
+        />
+
+        <NotebookCell
+          cellLabel="3"
+          frame={frame}
+          runWindow={[192, 266]}
+          editWindow={[386, 452]}
+          codeLines={['daily = logs.groupby("day").tokens.sum().reset_index()', 'daily']}
+          insertedLine={'daily["rolling"] = daily.tokens.ewm(span=3).mean()'}
+          output={<TrendOutput frame={frame} />}
+        />
+      </div>
+    </PanelShell>
+  );
+};
+
+const StepStrip = ({frame}: {frame: number}) => {
+  const intro = easeProgress(frame, 22, 74);
+  const steps = [
+    {label: 'Run cell 2', start: 72, end: 160},
+    {label: 'Run cell 3', start: 192, end: 320},
+    {label: 'Patch + rerun', start: 376, end: 570},
+  ];
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: 68,
+        right: 68,
+        bottom: 24,
+        display: 'grid',
+        gridTemplateColumns: 'repeat(3, 1fr)',
+        gap: 14,
+        opacity: intro,
+        transform: `translateY(${mix(18, 0, intro)}px)`,
+      }}
+    >
+      {steps.map((step) => {
+        const active = frame >= step.start && frame < step.end;
+        const done = frame >= step.end;
+        return (
+          <div
+            key={step.label}
+            style={{
+              padding: '14px 18px',
+              borderRadius: 20,
+              border: `1px solid ${active ? `${COLORS.orange}55` : 'rgba(174, 198, 215, 0.18)'}`,
+              background: active
+                ? 'rgba(255, 150, 81, 0.12)'
+                : done
+                  ? 'rgba(67, 215, 200, 0.11)'
+                  : 'rgba(255, 255, 255, 0.03)',
+            }}
+          >
+            <div
+              style={{
+                color: done ? COLORS.teal : active ? COLORS.amber : '#a4b7c4',
+                fontFamily: displayFont,
+                fontSize: 16,
+                fontWeight: 800,
+                textTransform: 'uppercase',
+                letterSpacing: '0.08em',
+              }}
+            >
+              {done ? 'Complete' : active ? 'Live' : 'Queued'}
+            </div>
+            <div
+              style={{
+                marginTop: 6,
+                color: '#f5f7fb',
+                fontFamily: displayFont,
+                fontSize: 24,
+                fontWeight: 700,
+                letterSpacing: '-0.03em',
+              }}
+            >
+              {step.label}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+const Background = ({frame}: {frame: number}) => {
+  const drift = Math.sin(frame / 42) * 18;
+  return (
+    <AbsoluteFill
+      style={{
+        background: `radial-gradient(circle at 18% 20%, rgba(255, 150, 81, 0.22) 0%, rgba(255, 150, 81, 0) 28%), radial-gradient(circle at 88% 18%, rgba(67, 215, 200, 0.12) 0%, rgba(67, 215, 200, 0) 22%), linear-gradient(140deg, #050b12 0%, #0b1722 44%, #09121c 100%)`,
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          backgroundImage:
+            'linear-gradient(rgba(128, 154, 170, 0.08) 1px, transparent 1px), linear-gradient(90deg, rgba(128, 154, 170, 0.08) 1px, transparent 1px)',
+          backgroundSize: '96px 96px',
+          maskImage: 'linear-gradient(180deg, rgba(0, 0, 0, 0.65), transparent)',
+        }}
+      />
+      <div
+        style={{
+          position: 'absolute',
+          width: 540,
+          height: 540,
+          borderRadius: '50%',
+          border: '1px solid rgba(126, 216, 255, 0.12)',
+          left: -120,
+          top: 380 + drift,
+        }}
+      />
+      <div
+        style={{
+          position: 'absolute',
+          width: 620,
+          height: 620,
+          borderRadius: '50%',
+          border: '1px solid rgba(255, 211, 106, 0.12)',
+          right: -120,
+          top: 180 - drift,
+        }}
+      />
+    </AbsoluteFill>
+  );
+};
+
+export const SkillShowcase = () => {
+  const frame = useCurrentFrame();
+  const stageIntro = easeProgress(frame, 10, 62);
+
+  return (
+    <AbsoluteFill>
+      <Background frame={frame} />
+      <HeaderBar frame={frame} />
+
+      <div
+        style={{
+          position: 'absolute',
+          left: 68,
+          right: 68,
+          top: 316,
+          bottom: 140,
+          display: 'flex',
+          gap: 28,
+          transform: `translateY(${mix(22, 0, stageIntro)}px)`,
+          opacity: stageIntro,
+        }}
+      >
+        <TerminalPane frame={frame} />
+        <NotebookPane frame={frame} />
+      </div>
+
+      <StepStrip frame={frame} />
+    </AbsoluteFill>
+  );
+};

--- a/video/src/index.ts
+++ b/video/src/index.ts
@@ -1,0 +1,4 @@
+import {registerRoot} from 'remotion';
+import {RemotionRoot} from './Root';
+
+registerRoot(RemotionRoot);

--- a/video/tsconfig.json
+++ b/video/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": false,
+    "noEmit": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["remotion"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add the Jupyter live kernel skill for discovering local servers, editing saved notebooks, executing against live kernels, and inspecting live variables
- add end-to-end tests for messy notebook edits and a realistic live-kernel iteration workflow
- add concise repo, skill, and agent docs plus the Remotion demo source

## Testing
- python3 -m unittest -v tests/test_jupyter_live_kernel.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new CLI surface that talks to local Jupyter servers, edits notebook files, and executes code over WebSocket/ZMQ; while mostly additive, mistakes could corrupt notebooks or run unintended code during agent workflows.
> 
> **Overview**
> Adds a new `jupyter-live-kernel` skill and CLI (`skills/jupyter-live-kernel/scripts/jupyter_live_kernel.py`) to discover local Jupyter servers, list live notebook sessions (plus workspace-derived notebook tabs), fetch saved notebook contents, edit notebook cells (replace/insert/move/delete/clear outputs) with a best-effort stale-write guard, and execute code/verification runs (`execute`, `run-all`, `restart-run-all`) against live kernels with `websocket`/`zmq` transport and safety checks to avoid double-execution.
> 
> Introduces bounded Python-only live variable inspection (`variables list/preview`) with token redaction and target-consistency validation, plus extensive unit/integration tests covering server discovery, editing behaviors, transport behavior, failure modes, and end-to-end demo workflows. Adds repo/agent documentation (`README.md`, `AGENTS.md`, skill docs/references, agent YAML) and basic ignores for Python artifacts and `video/` build outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6c9c6c8922f0861b8a6e3bc6dcd5f19ceb5d521. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->