### PR TITLE
docs(skill): explain installing packages into the live Jupyter kernel with uv

### DIFF
--- a/skills/jupyter-live-kernel/SKILL.md
+++ b/skills/jupyter-live-kernel/SKILL.md
@@ -9,13 +9,21 @@ Use this skill when a local notebook kernel already holds useful state and you d
 
 ## Starting JupyterLab
 
-When launching JupyterLab for use with this skill, disable token and password auth so the script can access the server API without browser session cookies:
+When launching JupyterLab for use with this skill, disable token and password auth so the script can access the server API without browser session cookies.
+
+If JupyterLab is installed in a virtual environment or with `uv tool install jupyterlab`, also export `VIRTUAL_ENV` and prepend the environment's `bin` directory to `PATH`. That lets notebook shell commands such as `!uv pip install pandas` install into the live kernel environment without passing `--python` explicitly.
+
+For a `uv tool install jupyterlab` setup:
 
 ```bash
-jupyter lab --IdentityProvider.token='' --ServerApp.password=''
+JUPYTER_ENV="$HOME/.local/share/uv/tools/jupyterlab"
+VIRTUAL_ENV="$JUPYTER_ENV" PATH="$JUPYTER_ENV/bin:$PATH" \
+  jupyter lab --IdentityProvider.token='' --ServerApp.password=''
 ```
 
-If the server is already running but returns 403 errors, restart it with these flags.
+For any other virtual environment, replace `JUPYTER_ENV` with that environment path. The `$HOME/.local/share/uv/tools/jupyterlab` path is the Linux default; run `uv tool dir` to print the base path on your platform (it differs on macOS and Windows).
+
+If the server is already running but returns 403 errors, restart it with the token/password flags. If `!uv pip install ...` says `No virtual environment found`, restart it with `VIRTUAL_ENV` set as shown above.
 
 ## Core Loop
 
@@ -102,6 +110,51 @@ Core guidance:
 - Use `--save-outputs` with `run-all` or `restart-run-all` to persist cell outputs into the notebook file so they appear in the JupyterLab UI.
 - When using `execute` with `--cell-id`, outputs are automatically saved to the notebook file (no need to pass `--save-outputs` separately). Without `--cell-id`, outputs are not saved.
 - To use the kernel as a pure REPL without persisting outputs, pass `--no-save-outputs`. This suppresses the automatic save even when `--cell-id` is provided. Only use this flag when the user explicitly says they don't need the notebook updated (e.g. "run this headlessly", "I don't care about the notebook output"). Default to saving outputs.
+
+## Installing Packages Into The Live Kernel
+
+Start JupyterLab with `VIRTUAL_ENV` pointing at the environment that backs the
+kernel (see Starting JupyterLab above). Notebook shell commands then install into
+the live kernel environment without extra flags:
+
+```python
+!uv pip install pandas matplotlib
+```
+
+Avoid `!pip install ...` and `uv pip install --system` for the live kernel. When
+`pip` targets an externally managed interpreter (Debian, Ubuntu, Raspberry Pi OS,
+Homebrew), `pip install` is blocked by [PEP 668](https://peps.python.org/pep-0668/),
+and `--system` can target the wrong interpreter. Installing into the kernel's
+environment keeps packages scoped to the live kernel.
+
+If the server was started without `VIRTUAL_ENV`, `uv pip install ...` can fail
+with `No virtual environment found`. Restart JupyterLab with `VIRTUAL_ENV` set,
+as shown in Starting JupyterLab.
+
+To debug the target environment, inspect it from the notebook:
+
+```python
+import os, sys
+print(sys.executable)
+print(os.environ.get("VIRTUAL_ENV"))
+```
+
+If `sys.executable` is not inside `VIRTUAL_ENV` (for example, a separate
+project-venv kernel), `VIRTUAL_ENV`-based installs miss the kernel. Install into
+the exact kernel interpreter instead:
+
+```bash
+uv pip install --python /path/to/kernel/python pandas matplotlib
+```
+
+From inside a notebook, derive that path from `sys.executable`:
+
+```python
+import sys
+!uv pip install --python {sys.executable} pandas matplotlib
+```
+
+Restart the kernel after installing packages if imports still fail.
 
 ## Target Selection And Ambiguity
 


### PR DESCRIPTION
## What

Documents how to install Python packages into the live Jupyter kernel environment, focused on JupyterLab installed via `uv tool install jupyterlab`.

## Why

When JupyterLab is installed as a uv tool, the kernel interpreter lives inside the tool env but `VIRTUAL_ENV` is not set. As a result, `!uv pip install pandas` inside a notebook fails with `No virtual environment found`, which is confusing because the kernel is clearly running from that env.

## Changes (docs only)

- **Starting JupyterLab**: show launching with `VIRTUAL_ENV` set and the env's `bin` on `PATH`, so `!uv pip install ...` targets the live kernel without `--python`. Note that the `~/.local/share/uv/tools/jupyterlab` path is the Linux default and `uv tool dir` prints the base path on other platforms.
- New **Installing Packages Into The Live Kernel** section: the recommended `VIRTUAL_ENV` setup, a snippet to inspect `sys.executable` / `VIRTUAL_ENV`, and an explicit `uv pip install --python {sys.executable}` fallback for when the kernel runs from a different environment than the JupyterLab server.
- Caution against `!pip install` / `uv pip install --system` when pip targets an externally managed interpreter ([PEP 668](https://peps.python.org/pep-0668/)).

No script, test, or behavior changes.

## Validation

Verified end-to-end on Linux (uv 0.11.21, JupyterLab as a uv tool):

- `uv pip install` without `VIRTUAL_ENV` reproduces `No virtual environment found`; with `VIRTUAL_ENV` set it resolves into that env.
- In a live kernel launched with `VIRTUAL_ENV` set, `!uv pip install <pkg>` installs into the kernel's env and `import <pkg>` loads from it — confirmed for both the bare `!uv pip install` form and the explicit `--python {sys.executable}` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
